### PR TITLE
Add binaries location to PATH when cross-compiling

### DIFF
--- a/golang/wrapper.sh
+++ b/golang/wrapper.sh
@@ -90,4 +90,8 @@ if [ "$GOOS" = "wasi" ]; then
   export GOOS="js"
 fi
 
+if [ -z "$GOBIN" ] && [ -n "$GOPATH" ] && [ -n "$GOARCH" ] && [ -n "$GOOS" ]; then
+  export PATH=${GOPATH}/bin/${GOOS}_${GOARCH}:${PATH}
+fi
+
 exec /usr/local/go/bin/go "$@"


### PR DESCRIPTION
This PR allows to add binaries location to PATH when cross-compiling.

For example if we use `go install ./...` binaries will be located to a specific folder regarding it's cross-compilation.

`GOOS=darwin GOARCH=amd64 go install ./...` will go to `$GOPATH/bin/$GOOS_$GOARCH` or not depending of the `$BUILDPLATFORM`.

This is the case for [this Dockerfile](https://github.com/crazy-max/AdGuardHome/blob/master/Dockerfile#L34) where [we use `packr` tool](https://github.com/crazy-max/AdGuardHome/blob/master/main.go#L1-L3) through go generate.