### PR TITLE
Add C++ cross compilers to golang wrapper.h

### DIFF
--- a/golang/wrapper.sh
+++ b/golang/wrapper.sh
@@ -64,23 +64,29 @@ if [ "$CGO_ENABLED" = "1" ]; then
   case "$GOARCH" in
   "amd64")
     export CC="x86_64-linux-gnu-gcc"
+    export CXX="x86_64-linux-gnu-g++"
     ;;
   "ppc64le")
     export CC="powerpc64le-linux-gnu-gcc"
+    export CXX="powerpc64le-linux-gnu-g++"
     ;;
   "s390x")
     export CC="s390x-linux-gnu-gcc"
+    export CXX="s390x-linux-gnu-g++"
     ;;
   "arm64")
     export CC="aarch64-linux-gnu-gcc"
+    export CXX="aarch64-linux-gnu-g++"
     ;;
   "arm")
     case "$GOARM" in
     "5")
       export CC="arm-linux-gnueabi-gcc"
+      export CXX="arm-linux-gnueabi-g++"
       ;;
     *)
       export CC="arm-linux-gnueabihf-gcc"
+      export CXX="arm-linux-gnueabihf-g++"
       ;;
     esac
     ;;


### PR DESCRIPTION
I tried to use this Docker image to cross compile [go-face](https://github.com/Kagami/go-face).
But I ran into troubles as the library depends on C++ code, and the cross compiler wasn't used as the `CXX` environment variable wan't set. Adding this made it work.