### PR TITLE
xx-verify: allow static-pie for static check

### DIFF
--- a/base/test-verify.bats
+++ b/base/test-verify.bats
@@ -27,3 +27,28 @@ load 'assert'
   assert_failure
   assert_output --partial "not statically linked"
 }
+
+@test "static" {
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-aarch64.so.1, stripped"
+  export TARGETPLATFORM=linux/arm64
+  run xx-verify --static /idontexist
+  assert_failure
+  assert_output --partial "not statically linked"
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, with debug_info, not stripped"
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify --static /idontexist
+  assert_success
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, with debug_info, not stripped"
+  run xx-verify --static /idontexist
+  assert_success
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped"
+  export TARGETPLATFORM=linux/arm64
+  run xx-verify --static /idontexist
+  assert_success
+
+  unset XX_VERIFY_FILE_CMD_OUTPUT
+  unset TARGETPLATFORM
+}

--- a/base/xx-verify
+++ b/base/xx-verify
@@ -202,10 +202,15 @@ for f in "$@"; do
   fi
 
   if [ -n "$static" ] && { [ "$TARGETOS" = "linux" ] || [ "$TARGETOS" = "freebsd" ]; }; then
-    if ! echo "$out" | grep -E "statically linked|static-pie" >/dev/null; then
-      echo >&2 "file ${f} is not statically linked: $out"
-      exit 1
+    if echo "$out" | grep -E "statically linked|static-pie" >/dev/null; then
+      exit 0
     fi
+    if echo "$out" | grep " pie " | grep -v ", interpreter " >/dev/null; then
+      exit 0
+    fi
+
+    echo >&2 "file ${f} is not statically linked: $out"
+    exit 1
   fi
 
 done

--- a/base/xx-verify
+++ b/base/xx-verify
@@ -73,14 +73,20 @@ set +e
 for f in "$@"; do
   if [ "${f#-}" != "${f}" ]; then continue; fi
 
-  if [ ! -f "${f}" ]; then
-    echo >&2 "file not found: ${f}"
-    exit 1
-  fi
+  if [ -z "${XX_VERIFY_FILE_CMD_OUTPUT}" ]; then
 
-  if ! out=$(file -L -b "${f}" 2>&1); then
-    echo >&2 "failed to run file for ${f}: $out"
-    exit 1
+    if [ ! -f "${f}" ]; then
+      echo >&2 "file not found: ${f}"
+      exit 1
+    fi
+
+    if ! out=$(file -L -b "${f}" 2>&1); then
+      echo >&2 "failed to run file for ${f}: $out"
+      exit 1
+    fi
+
+  else
+    out="${XX_VERIFY_FILE_CMD_OUTPUT}"
   fi
 
   expOS=""

--- a/base/xx-verify
+++ b/base/xx-verify
@@ -202,7 +202,7 @@ for f in "$@"; do
   fi
 
   if [ -n "$static" ] && { [ "$TARGETOS" = "linux" ] || [ "$TARGETOS" = "freebsd" ]; }; then
-    if ! echo "$out" | grep "statically linked" >/dev/null; then
+    if ! echo "$out" | grep -E "statically linked|static-pie" >/dev/null; then
       echo >&2 "file ${f} is not statically linked: $out"
       exit 1
     fi


### PR DESCRIPTION
Some versions of `file` return this for static+pie.

Overall, I think we should switch to `readelf` from `file` for this but I need to do some reading on what is the most reliable way. @tiborvass I think you looked into this some time ago?

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>