### PR TITLE
Rust support

### DIFF
--- a/base/test-info-alpine.bats
+++ b/base/test-info-alpine.bats
@@ -65,6 +65,13 @@ load 'assert'
 @test "riscv64" {
   assert_equal "riscv64-alpine-linux-musl" "$(TARGETPLATFORM=linux/riscv64 xx-info triple)"
   assert_equal "riscv64" "$(TARGETPLATFORM=linux/riscv64 xx-info pkg-arch)"
+
+  assert_equal "riscv64gc-alpine-linux-musl" "$(TARGETPLATFORM=linux/riscv64 RISCV64_TARGET_ARCH=riscv64gc xx-info triple)"
+  assert_equal "riscv64" "$(TARGETPLATFORM=linux/riscv64 RISCV64_TARGET_ARCH=riscv64gc xx-info pkg-arch)" # does not change
+}
+
+@test "custom-vendor" {
+  assert_equal "riscv64-unknown-linux-musl" "$(TARGETPLATFORM=linux/riscv64 XX_VENDOR=unknown xx-info triple)"
 }
 
 @test "mips" {

--- a/base/test-info-debian.bats
+++ b/base/test-info-debian.bats
@@ -67,6 +67,10 @@ fi
 @test "riscv64" {
   assert_equal "riscv64-linux-gnu" "$(TARGETPLATFORM=linux/riscv64 xx-info triple)"
   assert_equal "riscv64" "$(TARGETPLATFORM=linux/riscv64 xx-info pkg-arch)"
+
+  assert_equal "riscv64gc-linux-gnu" "$(TARGETPLATFORM=linux/riscv64 RISCV64_TARGET_ARCH=riscv64gc xx-info triple)"
+  assert_equal "riscv64" "$(TARGETPLATFORM=linux/riscv64 RISCV64_TARGET_ARCH=riscv64gc xx-info pkg-arch)" # does not change
+  assert_equal "riscv64gc-unknown-linux-gnu" "$(TARGETPLATFORM=linux/riscv64 RISCV64_TARGET_ARCH=riscv64gc XX_VENDOR=unknown xx-info triple)"
 }
 
 @test "mips" {

--- a/base/xx-apk
+++ b/base/xx-apk
@@ -13,6 +13,8 @@ if [ -n "$XX_DEBUG_APK" ]; then
   set -x
 fi
 
+unset XX_VENDOR # vendor for installing packages is always alpine
+
 for l in $(xx-info env); do
   export "${l?}"
 done

--- a/base/xx-apk
+++ b/base/xx-apk
@@ -84,6 +84,7 @@ cmd() {
   fi
   n=$#
   iscompilerrt=
+  isrustlib=
   for a in "$@"; do
     if [ $# = $n ]; then set --; fi
     case "$a" in
@@ -96,6 +97,10 @@ cmd() {
       "compiler-rt" | "compiler-rt-static")
         iscompilerrt=1
         set -- "$@" "$a"
+        ;;
+      "rust-stdlib")
+        set -- "$@" rust-stdlib
+        isrustlib=1
         ;;
       *)
         set -- "$@" "$a"
@@ -120,6 +125,10 @@ cmd() {
           ln -s "$f" "${ff}"
         fi
       done
+    fi
+    # rust stdlib is accessed from the real root
+    if [ -n "$isrustlib" ] && [ -d "$root/usr/lib/rustlib/$(xx-info)" ]; then
+      ln -s "$root/usr/lib/rustlib/$(xx-info)" "/usr/lib/rustlib/$(xx-info)" || true
     fi
   fi
 }

--- a/base/xx-cargo
+++ b/base/xx-cargo
@@ -1,0 +1,83 @@
+#!/usr/bin/env sh
+
+set -e
+
+if [ -z "$XX_CARGO_NOLOCK" ]; then
+  lock="/var/lock/xx-cargo"
+  exec 9>$lock
+  flock -x 9
+  export XX_CARGO_NOLOCK=1
+fi
+
+if [ -n "$XX_DEBUG_CARGO" ]; then
+  set -x
+fi
+
+setuponly=
+printtarget=
+n=$#
+for a in "$@"; do
+  if [ $# = $n ]; then set --; fi
+  case "$a" in
+    "--setup-target-triple")
+      setuponly=1
+      ;;
+    "--print-target")
+      printtarget=1
+      ;;
+    *)
+      set -- "$@" "$a"
+      ;;
+  esac
+done
+
+done_file="/.xx-cargo.$(xx-info arch)"
+
+export RISCV64_TARGET_ARCH=riscv64gc
+
+rustup=
+if which rustup >/dev/null 2>&1; then
+  rustup=1
+fi
+
+if [ -n "$rustup" ] || [ ! -f /etc/alpine-release ]; then
+  export XX_VENDOR="unknown"
+fi
+
+if [ ! -f "$done_file" ]; then
+  xx-clang --setup-target-triple
+  if [ ! -d "$(rustc --print sysroot)/lib/rustlib/$(xx-info)" ]; then
+    if [ -n "$rustup" ]; then
+      rustup target add "$(xx-info)" 2>/dev/null >/dev/null
+    elif [ -f /etc/alpine-release ]; then
+      xx-apk add rust-stdlib 2>/dev/null >/dev/null
+    else
+      xx-apt install -y libstd-rust-dev 2>/dev/null >/dev/null
+    fi
+  fi
+  touch "$done_file"
+fi
+
+export "CARGO_TARGET_$(xx-info | tr '[:lower:]' '[:upper:]' | tr - _)_LINKER=$(xx-info)-clang"
+if [ -n "$XX_RUSTFLAGS" ]; then
+  export "CARGO_TARGET_$(xx-info | tr '[:lower:]' '[:upper:]' | tr - _)_RUSTFLAGS=$XX_RUSTFLAGS"
+fi
+export "CC_$(xx-info | tr - _)=$(xx-info)-clang"
+
+if which "qemu-$(RISCV64_TARGET_ARCH='' xx-info march)" >/dev/null 2>&1; then
+  export "CARGO_TARGET_$(xx-info | tr '[:lower:]' '[:upper:]' | tr - _)_RUNNER=qemu-$(RISCV64_TARGET_ARCH='' xx-info march)"
+  if [ -f /etc/alpine-release ]; then
+    export "QEMU_LD_PREFIX=/$(RISCV64_TARGET_ARCH='' xx-info)/"
+  else
+    export "QEMU_LD_PREFIX=/lib/$(RISCV64_TARGET_ARCH='' XX_VENDOR='' xx-info)/"
+  fi
+fi
+
+if [ -n "$printtarget" ]; then
+  xx-info
+  exit 0
+fi
+
+if [ -z "$setuponly" ]; then
+  cargo "$@" --target="$(xx-info)"
+fi

--- a/base/xx-cc
+++ b/base/xx-cc
@@ -567,7 +567,7 @@ EOT
     fi
   fi
 
-  config="--target=${target} -fuse-ld=${linker}"
+  config="--target=$(echo "${target}" | sed s/^riscv64gc-/riscv64-/) -fuse-ld=${linker}"
   if [ "${nativeTarget}" != "${target}" ]; then
     if [ "$targetos" = "darwin" ]; then
       detectMacOSSDK
@@ -601,7 +601,7 @@ EOT
 
   if [ -f /etc/alpine-release ]; then
     # if vendor is not alpine then sysroot needs to be linked to the custom vendor
-    alpinetriple=$(echo "$target" | sed s/-[[:alpha:]][[:alpha:]]*-/-alpine-/)
+    alpinetriple=$(echo "$target" | sed s/-[[:alpha:]][[:alpha:]]*-/-alpine-/ | sed s/^riscv64gc-/riscv64-/)
     if [ "$target" != "$alpinetriple" ]; then
       # shellcheck disable=SC2044
       for f in $(find / -type d -name "$alpinetriple"); do

--- a/base/xx-cc
+++ b/base/xx-cc
@@ -588,6 +588,7 @@ export PKG_CONFIG_LIBDIR=/${target}/usr/lib/pkgconfig/
 exec pkg-config "\$@"
 EOT
       chmod +x "/usr/bin/${target}-pkg-config"
+
     fi
   elif [ ! -f "/usr/bin/${target}-pkg-config" ] && [ ! -h "/usr/bin/${target}-pkg-config" ]; then
     ln -s pkg-config "/usr/bin/${target}-pkg-config"
@@ -596,6 +597,17 @@ EOT
   echo "$config" >"${f}"
   if [ "${f}" != "/usr/bin/${target}.cfg" ]; then
     ln -s "${f}" "/usr/bin/${target}.cfg"
+  fi
+
+  if [ -f /etc/alpine-release ]; then
+    # if vendor is not alpine then sysroot needs to be linked to the custom vendor
+    alpinetriple=$(echo "$target" | sed s/-[[:alpha:]][[:alpha:]]*-/-alpine-/)
+    if [ "$target" != "$alpinetriple" ]; then
+      # shellcheck disable=SC2044
+      for f in $(find / -type d -name "$alpinetriple"); do
+        ln -s "$alpinetriple" "$(dirname "$f")/$target"
+      done
+    fi
   fi
 
   if [ "${targetos}" = "darwin" ]; then

--- a/base/xx-info
+++ b/base/xx-info
@@ -123,12 +123,11 @@ if [ -z "$XX_VENDOR" ]; then
   if [ -z "$XX_VENDOR" ]; then
     XX_VENDOR="unknown"
   fi
-  if [ "$XX_VENDOR" != "unknown" ] && [ "$XX_VENDOR" != "debian" ]; then
-    vendor="-${XX_VENDOR}"
-  fi
-else
-  vendor="-${XX_VENDOR}"
 fi
+case "$XX_VENDOR" in
+  debian | ubuntu | rhel | fedora | centos | rocky | ol) ;;
+  *) vendor="-${XX_VENDOR}" ;;
+esac
 
 if [ -z "$XX_LIBC" ]; then
   if [ "$distro" = "alpine" ]; then
@@ -399,6 +398,7 @@ case "$1" in
     echo "XX_OS_VERSION=${XX_OS_VERSION}"
     echo "XX_ARCH=${TARGETARCH}"
     echo "XX_MARCH=${XX_MARCH}"
+    echo "XX_VENDOR=${XX_VENDOR}"
     if [ "$TARGETOS" = "linux" ]; then
       echo "XX_PKG_ARCH=${XX_PKG_ARCH}"
     fi

--- a/base/xx-info
+++ b/base/xx-info
@@ -273,7 +273,11 @@ case "$TARGETARCH" in
     XX_DEBIAN_ARCH="riscv64"
     XX_ALPINE_ARCH="riscv64"
     XX_RHEL_ARCH="riscv64"
-    XX_TRIPLE="riscv64${vendor}-linux-${XX_LIBC}"
+    triplearch="riscv64"
+    if [ -n "$RISCV64_TARGET_ARCH" ]; then
+      triplearch="${RISCV64_TARGET_ARCH}"
+    fi
+    XX_TRIPLE="${triplearch}${vendor}-linux-${XX_LIBC}"
     ;;
   "ppc64le")
     XX_MARCH="ppc64le"

--- a/base/xx-info
+++ b/base/xx-info
@@ -15,7 +15,7 @@
 : "${XX_RHEL_ARCH=unknown}"
 : "${XX_OS_VERSION=unknown}"
 : "${XX_TRIPLE=unknown-unknown-none}"
-: "${XX_VENDOR=unknown}"
+: "${XX_VENDOR=}"
 : "${XX_LIBC=}"
 
 usage() {
@@ -105,27 +105,33 @@ if [ -n "$TARGETPLATFORM" ]; then
   fi
 fi
 
+distro=""
 # detect distro vendor
-if [ "$TARGETOS" = "darwin" ]; then
-  XX_VENDOR="apple"
-elif [ -f /etc/os-release ]; then
-  # shellcheck disable=SC1091
-  if . /etc/os-release 2>/dev/null; then
-    XX_VENDOR=$ID
-    XX_OS_VERSION=$VERSION_ID
-  fi
+# shellcheck disable=SC1091
+if . /etc/os-release 2>/dev/null; then
+  distro=$ID
 fi
 
 vendor=""
-case "$XX_VENDOR" in
-  unknown | debian | ubuntu | rhel | fedora | centos | rocky | ol) ;;
-  *)
+if [ -z "$XX_VENDOR" ]; then
+  if [ -n "$distro" ]; then
+    XX_VENDOR="$distro"
+  fi
+  if [ "$TARGETOS" = "darwin" ]; then
+    XX_VENDOR="apple"
+  fi
+  if [ -z "$XX_VENDOR" ]; then
+    XX_VENDOR="unknown"
+  fi
+  if [ "$XX_VENDOR" != "unknown" ] && [ "$XX_VENDOR" != "debian" ]; then
     vendor="-${XX_VENDOR}"
-    ;;
-esac
+  fi
+else
+  vendor="-${XX_VENDOR}"
+fi
 
 if [ -z "$XX_LIBC" ]; then
-  if [ "$XX_VENDOR" = "alpine" ]; then
+  if [ "$distro" = "alpine" ]; then
     XX_LIBC="musl"
   else
     XX_LIBC="gnu"
@@ -389,7 +395,6 @@ case "$1" in
     echo "XX_OS_VERSION=${XX_OS_VERSION}"
     echo "XX_ARCH=${TARGETARCH}"
     echo "XX_MARCH=${XX_MARCH}"
-    echo "XX_VENDOR=${XX_VENDOR}"
     if [ "$TARGETOS" = "linux" ]; then
       echo "XX_PKG_ARCH=${XX_PKG_ARCH}"
     fi


### PR DESCRIPTION
Allow building rust projects. Support installing rust via `rustup` (alpine/debian) and alpine packages (rust/rust-stdlib). Haven't tested official image. Debian package-based installs will probably not be supported as packages don't seem to be properly separated.

 Currently have tested with these Dockerfile stages:

```
ARG RUST_ALG=alpine-rustup

FROM --platform=$BUILDPLATFORM alpine AS rust-alpine-rustup
COPY --from=xx / /
RUN apk add clang lld musl-dev gcc git curl
WORKDIR /work
RUN curl -O https://static.rust-lang.org/rustup/archive/1.24.3/$(XX_VENDOR=unknown xx-info)/rustup-init && \
    chmod +x rustup-init && \
    ./rustup-init -y --no-modify-path --profile=minimal
ENV PATH=/root/.cargo/bin:$PATH
RUN git clone git://github.com/BLAKE3-team/BLAKE3.git
WORKDIR BLAKE3/b3sum
RUN cargo fetch
ARG TARGETPLATFORM
RUN xx-apk add musl-dev gcc
ENV XX_VENDOR=unknown
RUN xx-clang --setup-target-triple
RUN rustup target add $(xx-info)
RUN export CARGO_TARGET_$(xx-info | tr '[:lower:]' '[:upper:]' | tr - _)_LINKER=$(xx-info)-clang && \
    export CARGO_TARGET_$(xx-info | tr '[:lower:]' '[:upper:]' | tr - _)_RUSTFLAGS="" && \
    export CC_$(xx-info | tr - _)=$(xx-info)-clang && \
    env && cargo build --release --target-dir /tmp/blake --target $(xx-info) && \
    mkdir -p /out && cp /tmp/blake/$(xx-info)/release/b3sum /out/ && \
    xx-verify --static /out/b3sum && rm -rf /tmp/blake

FROM --platform=$BUILDPLATFORM alpine:edge AS rust-apk
COPY --from=xx / /
RUN apk add clang lld musl-dev gcc git rust cargo
WORKDIR /work
RUN git clone git://github.com/BLAKE3-team/BLAKE3.git
WORKDIR BLAKE3/b3sum
RUN cargo fetch
ARG TARGETPLATFORM
RUN xx-apk add musl-dev gcc rust-stdlib
RUN xx-clang --setup-target-triple
RUN export CARGO_TARGET_$(xx-info | tr '[:lower:]' '[:upper:]' | tr - _)_LINKER=$(xx-info)-clang && \
    export CARGO_TARGET_$(xx-info | tr '[:lower:]' '[:upper:]' | tr - _)_RUSTFLAGS="-C target-feature=+crt-static" && \
    export CC_$(xx-info | tr - _)=$(xx-info)-clang && \
    env && cargo build --release --target-dir /tmp/blake --target $(xx-info) && \
    mkdir -p /out && cp /tmp/blake/$(xx-info)/release/b3sum /out/ && \
    xx-verify /out/b3sum && rm -rf /tmp/blake
# alpine rust disables static linking? https://github.com/alpinelinux/aports/commit/69851bdae1177246337f51a35734e93f1fd7e3d3#diff-92eb9787919d42fb458bdae3211d4ee3d18385106441d644ec49b10ec3dfaa8c

FROM --platform=$BUILDPLATFORM debian:sid AS rust-debian-rustup
COPY --from=xx / /
RUN apt update && apt-get install -y clang lld libc6-dev binutils libc6-dev git curl
WORKDIR /work
RUN curl -O https://static.rust-lang.org/rustup/archive/1.24.3/$(XX_VENDOR=unknown xx-info)/rustup-init && \
    chmod +x rustup-init && \
    ./rustup-init -y --no-modify-path --profile=minimal
ENV PATH=/root/.cargo/bin:$PATH
RUN git clone git://github.com/BLAKE3-team/BLAKE3.git
WORKDIR BLAKE3/b3sum
RUN cargo fetch
ARG TARGETPLATFORM
RUN xx-apt install -y libc6-dev libgcc-10-dev
ENV XX_VENDOR=unknown
RUN xx-clang --setup-target-triple
RUN rustup target add $(xx-info)
RUN export CARGO_TARGET_$(xx-info | tr '[:lower:]' '[:upper:]' | tr - _)_LINKER=$(xx-info)-clang && \
    export CARGO_TARGET_$(xx-info | tr '[:lower:]' '[:upper:]' | tr - _)_RUSTFLAGS="-C target-feature=+crt-static" && \
    export CC_$(xx-info | tr - _)=$(xx-info)-clang && \
    env && cargo build --release --target-dir /tmp/blake --target $(xx-info) && \
    mkdir -p /out && cp /tmp/blake/$(xx-info)/release/b3sum /out/ && \
    xx-verify --static /out/b3sum && rm -rf /tmp/blake

FROM rust-${RUST_ALG} as rust-build

FROM scratch AS b3sum
COPY --from=rust-build /out/b3sum /
```

The main complexity is that the binary releases use triple with `unknown` vendor instead of `alpine` and as C compiler always gets called with `cc --target=wrong-triple` it doesn't really matter that the CC is wrapped. I've added a way for `cc-clang` to work with any vendor by creating symlinks to the official ones. An alternative would be to try to rename the `--target` flag in the wrapper.

I think it makes sense to add `xx-cargo` script that would set the 3 env automatically. `xx-cargo --setup-target` could make the correct calls to `rustup target add` or `xx-apk add rust-stdlib` (and set up `xx-clang` for correct triple).

Risc-V doesn't currently work because the gnu triple is `riscv64gc-*` not `riscv64`. Might need some special override for that. In `alpine:edge` there is no riscv package for `rust-stdlib` yet, and no musl build in `rustup` either.

- [x] add `xx-cargo`
- [x] support `riscv64gc-gnu` triple
- [ ] CI testing

@crazy-max 