### PR TITLE
Install GNU wget if it fails

### DIFF
--- a/base/xx-cc
+++ b/base/xx-cc
@@ -8,15 +8,29 @@ if [ -n "$XX_MIRROR" ]; then
   mirrors="$XX_MIRROR"
 fi
 
+_wget() {
+  if ! wget "$@"; then
+    if [ "$(wget --help 2>&1 | head -n1 | cut -d' ' -f1)" = "GNU" ]; then
+      return 1
+    fi
+    installwget
+    wget "$@"
+  fi
+}
+
 ensurewget() {
   # wget is almost always installed but just in case
   if ! which wget >/dev/null 2>/dev/null; then
-    if which apt >/dev/null 2>/dev/null; then
-      apt update >/dev/null 2>/dev/null && apt install -y --no-install-recommends wget >/dev/null 2>/dev/null
-    fi
-    if which apk >/dev/null 2>/dev/null; then
-      apk add wget
-    fi
+    installwget
+  fi
+}
+
+installwget() {
+  if which apt >/dev/null 2>/dev/null; then
+    apt update >/dev/null 2>/dev/null && apt install -y --no-install-recommends wget >/dev/null 2>/dev/null
+  fi
+  if which apk >/dev/null 2>/dev/null; then
+    apk add wget >/dev/null 2>/dev/null
   fi
 }
 
@@ -198,9 +212,8 @@ EOT
   tmpdir=$(mktemp -d)
 
   for m in $mirrors; do
-    # busybox wget
-    if ! wget "$m/$file.tar.gz" -q -O "$tmpdir/$file.tar.gz" >/dev/null 2>/dev/null; then
-      if ! wget --no-check-certificate "$m/$file.tar.gz" -q -O "$tmpdir/$file.tar.gz" >/dev/null 2>/dev/null; then
+    if ! _wget "$m/$file.tar.gz" -q -O "$tmpdir/$file.tar.gz" >/dev/null 2>/dev/null; then
+      if ! _wget --no-check-certificate "$m/$file.tar.gz" -q -O "$tmpdir/$file.tar.gz" >/dev/null 2>/dev/null; then
         continue
       fi
     fi
@@ -315,9 +328,8 @@ EOT
   tmpdir=$(mktemp -d)
 
   for m in $mirrors; do
-    # busybox wget
-    if ! wget "$m/$file.tar.gz" -q -O "$tmpdir/$file.tar.gz" >/dev/null 2>/dev/null; then
-      if ! wget --no-check-certificate "$m/$file.tar.gz" -q -O "$tmpdir/$file.tar.gz" >/dev/null 2>/dev/null; then
+    if ! _wget "$m/$file.tar.gz" -q -O "$tmpdir/$file.tar.gz" >/dev/null 2>/dev/null; then
+      if ! _wget --no-check-certificate "$m/$file.tar.gz" -q -O "$tmpdir/$file.tar.gz" >/dev/null 2>/dev/null; then
         continue
       fi
     fi


### PR DESCRIPTION
Make sure to use GNU Wget and not the buysbox one because Busybox's wget stopped when it couldn't reach the IPv6 destination. Standard wget, instead, falls back to the IPv4 address, completing the download.

If `wget --version` is ok that's the GNU one, otherwise fails with `wget: unrecognized option: version` on busybox. Maybe we could use a better check.

```shell
docker buildx build --load -<<EOF
FROM golang:1.17.0-alpine AS build
RUN (wget --version || true) && which wget
RUN apk add wget
RUN wget --version && which wget
EOF
```

```
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 167B done
#1 DONE 0.0s

#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/golang:1.17.0-alpine
#3 DONE 0.9s

#4 [1/4] FROM docker.io/library/golang:1.17.0-alpine@sha256:c03a922dfb0d6d3a94d46cc5be69002011763595ac2786068fde63ee174d797b
#4 resolve docker.io/library/golang:1.17.0-alpine@sha256:c03a922dfb0d6d3a94d46cc5be69002011763595ac2786068fde63ee174d797b 0.0s done
#4 CACHED

#5 [2/4] RUN (wget --version || true) && which wget
#5 0.135 wget: unrecognized option: version
#5 0.140 BusyBox v1.33.1 () multi-call binary.
#5 0.140
#5 0.140 Usage: wget [-cqS] [--spider] [-O FILE] [-o LOGFILE] [--header 'HEADER: VALUE'] [-Y on/off]
#5 0.140        [-P DIR] [-U AGENT] [-T SEC] URL...
#5 0.140
#5 0.140 Retrieve files via HTTP or FTP
#5 0.140
#5 0.140        --spider        Only check URL existence: $? is 0 if exists
#5 0.140        -c              Continue retrieval of aborted transfer
#5 0.140        -q              Quiet
#5 0.140        -P DIR          Save to DIR (default .)
#5 0.140        -S              Show server response
#5 0.140        -T SEC          Network read timeout is SEC seconds
#5 0.140        -O FILE         Save to FILE ('-' for stdout)
#5 0.140        -o LOGFILE      Log messages to FILE
#5 0.140        -U STR          Use STR for User-Agent header
#5 0.140        -Y on/off       Use proxy
#5 0.141 /usr/bin/wget
#5 DONE 0.2s

#6 [3/4] RUN apk add wget
#6 0.174 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
#6 0.423 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
#6 0.753 (1/3) Installing libunistring (0.9.10-r1)
#6 0.816 (2/3) Installing libidn2 (2.3.1-r0)
#6 0.859 (3/3) Installing wget (1.21.1-r1)
#6 0.916 Executing busybox-1.33.1-r3.trigger
#6 0.924 OK: 8 MiB in 18 packages
#6 DONE 1.0s

#7 [4/4] RUN wget --version && which wget
#7 0.122 GNU Wget 1.21.1 built on linux-musl.
#7 0.122
#7 0.122 -cares +digest -gpgme +https +ipv6 +iri +large-file -metalink -nls 
#7 0.122 +ntlm +opie -psl +ssl/openssl
#7 0.122
#7 0.122 Wgetrc:
#7 0.122     /etc/wgetrc (system)
#7 0.122 Compile:
#7 0.122     gcc -DHAVE_CONFIG_H -DSYSTEM_WGETRC="/etc/wgetrc"
#7 0.122     -DLOCALEDIR="/usr/share/locale" -I. -I../lib -I../lib -Os
#7 0.122     -fomit-frame-pointer -DHAVE_LIBSSL -DNDEBUG -Os
#7 0.122     -fomit-frame-pointer
#7 0.122 Link:
#7 0.122     gcc -DHAVE_LIBSSL -DNDEBUG -Os -fomit-frame-pointer -lidn2 -lssl
#7 0.122     -lcrypto ftp-opie.o openssl.o http-ntlm.o ../lib/libgnu.a
#7 0.122
#7 0.122 Copyright (C) 2015 Free Software Foundation, Inc.
#7 0.122 License GPLv3+: GNU GPL version 3 or later
#7 0.122 <http://www.gnu.org/licenses/gpl.html>.
#7 0.122 This is free software: you are free to change and redistribute it.
#7 0.122 There is NO WARRANTY, to the extent permitted by law.
#7 0.122
#7 0.122 Originally written by Hrvoje Niksic <hniksic@xemacs.org>.
#7 0.122 Please send bug reports and questions to <bug-wget@gnu.org>.
#7 0.122 /usr/bin/wget
#7 DONE 0.1s

#8 exporting to oci image format
#8 exporting layers
#8 exporting layers 2.9s done
#8 exporting manifest sha256:a0d0af9469548cb9f410954e3a5862ff859c59ac7ff444a37709f6c734a61ea9 0.0s done
#8 exporting config sha256:b54d776f5904e763c8764fd10d94db04becf0598037cb72f717540fb5dc16c16 0.0s done
#8 sending tarball
#8 sending tarball 1.4s done
#8 DONE 4.4s

#9 importing to docker
#9 DONE 0.1s
```

cc @tonistiigi 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>