### PR TITLE
Allow failure on step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       fail-fast: false
       matrix:
@@ -65,6 +64,7 @@ jobs:
         uses: actions/checkout@v2
       -
         name: Test
+        continue-on-error: ${{ matrix.allow-failure }}
         uses: docker/bake-action@v1
         with:
           targets: test-${{ matrix.typ }}


### PR DESCRIPTION
Follow-up https://github.com/tonistiigi/xx/pull/30#issuecomment-913644010

Build will be green but failure annotation will still be there:

![image](https://user-images.githubusercontent.com/1951866/132234797-cdf8f7de-2e4b-4290-ba43-c1175d6bdff3.png)

cc @thaJeztah

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>