### PR TITLE
remove usage of which

### DIFF
--- a/base/test-go.bats
+++ b/base/test-go.bats
@@ -24,7 +24,7 @@ testEnv() {
 }
 
 @test "native-env" {
-  if which apk >/dev/null 2>/dev/null; then
+  if command -v apk >/dev/null 2>/dev/null; then
     add go
   else
     add golang
@@ -270,7 +270,7 @@ testHelloCGO() {
   done
   del clang lld llvm
   del pkgconfig || del pkg-config
-  if which apk >/dev/null 2>/dev/null; then
+  if command -v apk >/dev/null 2>/dev/null; then
     del go
   else
     del golang

--- a/base/test_helper.bash
+++ b/base/test_helper.bash
@@ -57,12 +57,12 @@ xxrun() {
       ln -s clang-11 /usr/bin/clang
       ln -s clang++-11 /usr/bin/clang++
     fi
-    if [ ! -f /usr/bin/clang-11 ] && [ "clang11" = "$(readlink $(which clang))" ]; then
+    if [ ! -f /usr/bin/clang-11 ] && [ "clang11" = "$(readlink $(command -v clang))" ]; then
       rm /usr/bin/clang
       rm /usr/bin/clang++
     fi
   fi
-  if [ -n "$wasgolang" ] && ! which go 2>/dev/null >/dev/null; then
+  if [ -n "$wasgolang" ] && ! command -v go 2>/dev/null >/dev/null; then
     ln -s /usr/lib/go-1.15/bin/go /usr/bin/go
   fi
 }

--- a/base/xx-cc
+++ b/base/xx-cc
@@ -20,16 +20,16 @@ _wget() {
 
 ensurewget() {
   # wget is almost always installed but just in case
-  if ! which wget >/dev/null 2>/dev/null; then
+  if ! command -v wget >/dev/null 2>/dev/null; then
     installwget
   fi
 }
 
 installwget() {
-  if which apt >/dev/null 2>/dev/null; then
+  if command -v apt >/dev/null 2>/dev/null; then
     apt update >/dev/null 2>/dev/null && apt install -y --no-install-recommends wget >/dev/null 2>/dev/null
   fi
-  if which apk >/dev/null 2>/dev/null; then
+  if command -v apk >/dev/null 2>/dev/null; then
     apk add wget >/dev/null 2>/dev/null
   fi
 }
@@ -411,12 +411,12 @@ setup() {
   fi
 
   if [ "$targetos" = "darwin" ]; then
-    if which ld64.signed >/dev/null 2>/dev/null; then
-      linker=$(which ld64.signed)
+    if command -v ld64.signed >/dev/null 2>/dev/null; then
+      linker=$(command -v ld64.signed)
     else
       download_ld64
       if [ -z "$linker" ]; then
-        if ! which ld64 >/dev/null 2>/dev/null; then
+        if ! command -v ld64 >/dev/null 2>/dev/null; then
           echo >&2 "error: building for darwin requires ld64 linker"
         fi
         linker=ld64
@@ -425,14 +425,14 @@ setup() {
   fi
 
   if [ -z "$linker" ] && [ -n "$prefer_lld" ] && [ "${XX_CC_PREFER_LINKER}" = "lld" ]; then
-    if which lld >/dev/null 2>/dev/null; then
+    if command -v lld >/dev/null 2>/dev/null; then
       linker="lld"
     fi
   fi
 
   if [ -z "$linker" ] && [ "${XX_CC_PREFER_LINKER}" = "gold" ]; then
     if [ -z "${linker}" ]; then
-      ld=$(which "$target-gold" 2>/dev/null || true)
+      ld=$(command -v "$target-gold" 2>/dev/null || true)
       if [ -n "$ld" ]; then
         linker=${ld}
       fi
@@ -443,7 +443,7 @@ setup() {
   fi
 
   if [ -z "${linker}" ]; then
-    ld=$(which "$target-ld" 2>/dev/null || true)
+    ld=$(command -v "$target-ld" 2>/dev/null || true)
     if [ -n "$ld" ]; then
       linker=${ld}
       XX_CC_PREFER_LINKER=
@@ -454,7 +454,7 @@ setup() {
     XX_CC_PREFER_LINKER=
   fi
 
-  if [ -z "${linker}" ] && which ld >/dev/null 2>/dev/null; then
+  if [ -z "${linker}" ] && command -v ld >/dev/null 2>/dev/null; then
     exp=$targetarch
     if [ "$exp" = "amd64" ]; then
       exp="x86_64"
@@ -472,14 +472,14 @@ setup() {
       exp="riscv"
     fi
     if ld -V 2>/dev/null | grep $exp >/dev/null; then
-      ln -s "$(which ld)" "/usr/bin/${target}-ld"
+      ln -s "$(command -v ld)" "/usr/bin/${target}-ld"
       linker="/usr/bin/${target}-ld"
       XX_CC_PREFER_LINKER=
     fi
   fi
 
   if [ -z "$linker" ] && [ -n "$prefer_lld" ]; then
-    if which lld >/dev/null 2>/dev/null; then
+    if command -v lld >/dev/null 2>/dev/null; then
       linker="lld"
     fi
   fi
@@ -528,7 +528,7 @@ EOT
   done
 
   for f in addr2line ar as ranlib nm dlltool strip; do
-    if ! which "${target}-${f}" >/dev/null 2>/dev/null; then
+    if ! command -v "${target}-${f}" >/dev/null 2>/dev/null; then
       if [ -f "/usr/bin/llvm-${f}" ]; then
         if echo "${target}" | grep '\.' 2>/dev/null >/dev/null; then
           cat <<EOT >"/usr/bin/${target}-$f"
@@ -544,7 +544,7 @@ EOT
   done
 
   if [ "$targetos" = "windows" ]; then
-    if which llvm-rc 2>/dev/null >/dev/null; then
+    if command -v llvm-rc 2>/dev/null >/dev/null; then
       if [ ! -f "/usr/bin/${target}-windres" ] && [ ! -h "/usr/bin/${target}-windres" ]; then
         cat <<EOT >"/usr/bin/${target}-windres"
 #!/usr/bin/env sh
@@ -576,14 +576,14 @@ EOT
   elif [ ! -f "/usr/bin/${target}-pkg-config" ] && [ ! -h "/usr/bin/${target}-pkg-config" ]; then
     ln -s pkg-config "/usr/bin/${target}-pkg-config"
   fi
-  f="$(dirname "$(readlink -f "$(which /usr/bin/clang)")")/${target}.cfg"
+  f="$(dirname "$(readlink -f "$(command -v /usr/bin/clang)")")/${target}.cfg"
   echo "$config" >"${f}"
   if [ "${f}" != "/usr/bin/${target}.cfg" ]; then
     ln -s "${f}" "/usr/bin/${target}.cfg"
   fi
 
   if [ "${targetos}" = "darwin" ]; then
-    if ! which xcrun 2>/dev/null >/dev/null; then
+    if ! command -v xcrun 2>/dev/null >/dev/null; then
       writexcrun
     fi
   fi

--- a/base/xx-go
+++ b/base/xx-go
@@ -36,17 +36,17 @@ cxx_set=
 ar_set=
 pkgconfig_set=
 
-if which "$XX_TRIPLE-gcc" >/dev/null 2>/dev/null; then
+if command -v "$XX_TRIPLE-gcc" >/dev/null 2>/dev/null; then
   export CC=$XX_TRIPLE-gcc
   c_set=1
 fi
 
-if which "$XX_TRIPLE-g++" >/dev/null 2>/dev/null; then
+if command -v "$XX_TRIPLE-g++" >/dev/null 2>/dev/null; then
   export CXX=$XX_TRIPLE-g++
   cxx_set=1
 fi
 
-if which clang >/dev/null 2>/dev/null; then
+if command -v clang >/dev/null 2>/dev/null; then
   triple=$(xx-clang --print-target-triple || true)
   if [ -n "$triple" ]; then
     export CC=$triple-clang
@@ -56,12 +56,12 @@ if which clang >/dev/null 2>/dev/null; then
   fi
 fi
 
-if which "$XX_TRIPLE-ar" >/dev/null 2>/dev/null; then
+if command -v "$XX_TRIPLE-ar" >/dev/null 2>/dev/null; then
   export AR=$XX_TRIPLE-ar
   ar_set=1
 fi
 
-if which "$XX_TRIPLE-pkg-config" >/dev/null 2>/dev/null; then
+if command -v "$XX_TRIPLE-pkg-config" >/dev/null 2>/dev/null; then
   export PKG_CONFIG=$XX_TRIPLE-pkg-config
   pkgconfig_set=1
 fi

--- a/base/xx-verify
+++ b/base/xx-verify
@@ -18,10 +18,10 @@ for l in $(xx-info env); do
 done
 
 setup() {
-  if ! which file >/dev/null 2>/dev/null; then
-    if which apk >/dev/null; then
+  if ! command -v file >/dev/null 2>/dev/null; then
+    if command -v apk >/dev/null; then
       apk add --no-cache file >"$1"
-    elif which apt >/dev/null; then
+    elif command -v apt >/dev/null; then
       apt update && apt install -y file
     else
       echo >&2 "file not installed and no package manager not found"

--- a/base/xx-windres
+++ b/base/xx-windres
@@ -328,14 +328,14 @@ if [ "$inputf" = "rc" ]; then
     preprocessor=$CC
   fi
   if [ -z "$preprocessor" ]; then
-    if which clang >/dev/null 2>/dev/null; then
+    if command -v clang >/dev/null 2>/dev/null; then
       preprocessor="clang"
     else
       preprocessor="gcc"
     fi
   fi
 
-  if ! which llvm-rc 2>/dev/null >/dev/null; then
+  if ! command -v llvm-rc 2>/dev/null >/dev/null; then
     echo >&2 "llvm-rc not installed"
     exit 1
   fi
@@ -362,7 +362,7 @@ fi
 if [ "$outputf" = "res" ]; then
   run cp $resfile $output
 else
-  if ! which llvm-cvtres 2>/dev/null >/dev/null; then
+  if ! command -v llvm-cvtres 2>/dev/null >/dev/null; then
     echo >&2 "llvm-cvtres not installed"
     exit 1
   fi


### PR DESCRIPTION
debian has decided to remove it and break the world.

https://salsa.debian.org/debian/debianutils/-/commit/3a8dd10b4502f7bae8fc6973c13ce23fc9da7efb

This should make `debian:sid` green again.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>