### PR TITLE
xx-verify: Add FreeBSD-style to `expOS`

### DIFF
--- a/base/xx-verify
+++ b/base/xx-verify
@@ -85,8 +85,11 @@ for f in "$@"; do
 
   expOS=""
   case "$TARGETOS" in
-    "linux" | "freebsd")
+    "linux")
       expOS="ELF"
+      ;;
+    "freebsd")
+      expOS="ELF.*FreeBSD-style"
       ;;
     "darwin")
       expOS="Mach-O"


### PR DESCRIPTION
To distinguish between ELF Linux and FreeBSD binaries, we can check for
"FreeBSD-style" in the output of the file command.

This change adds this check.

Signed-off-by: Artem Khramov <akhramov@pm.me>