### PR TITLE
xx-verify: add more tests improve os coverage

### DIFF
--- a/base/test-verify.bats
+++ b/base/test-verify.bats
@@ -52,3 +52,293 @@ load 'assert'
   unset XX_VERIFY_FILE_CMD_OUTPUT
   unset TARGETPLATFORM
 }
+
+@test "darwin" {
+  export XX_VERIFY_FILE_CMD_OUTPUT=": Mach-O 64-bit executable x86_64"
+  export TARGETPLATFORM=darwin/amd64
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=darwin/arm64
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=windows/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": Mach-O 64-bit executable arm64"
+  export TARGETPLATFORM=darwin/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=darwin/arm64
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=darwin/arm
+  run xx-verify /idontexist
+  assert_failure
+
+  unset XX_VERIFY_FILE_CMD_OUTPUT
+  unset TARGETPLATFORM
+}
+
+@test "windows" {
+  export XX_VERIFY_FILE_CMD_OUTPUT=": PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows"
+  export TARGETPLATFORM=windows/amd64
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=windows/arm64
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=darwin/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": PE32+ executable (console) Aarch64 (stripped to external PDB), for MS Windows"
+  export TARGETPLATFORM=windows/arm64
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=windows/arm
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=windows/arm
+  run xx-verify /idontexist
+  assert_failure
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": PE32 executable (console) ARMv7 Thumb (stripped to external PDB), for MS Windows"
+  export TARGETPLATFORM=windows/arm
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=windows/arm64
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=linux/arm
+  run xx-verify /idontexist
+  assert_failure
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": PE32 executable (console) Intel 80386 (stripped to external PDB), for MS Windows"
+  export TARGETPLATFORM=windows/386
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=windows/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=linux/386
+  run xx-verify /idontexist
+  assert_failure
+
+  unset XX_VERIFY_FILE_CMD_OUTPUT
+  unset TARGETPLATFORM
+}
+
+@test "linux" {
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, stripped"
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=linux/arm64
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=darwin/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=windows/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=freebsd/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, stripped"
+  export TARGETPLATFORM=linux/arm64
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=linux/arm
+  run xx-verify /idontexist
+  assert_failure
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=9SFsUdDWBnHFg66bZmbU/swMmjBFa_SysaP8A8W_u/X4c8ljiSZkLzFJZnxQ69/BRIIL6S2KBBMnmo4nsZZ, not stripped"
+  export TARGETPLATFORM=linux/arm
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=linux/arm/v6
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=linux/arm64
+  run xx-verify /idontexist
+  assert_failure
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, Go BuildID=GUb5psm2_Qmc_LlEF7GP/wcIHIg_4MjQh8NC5wfep/LSmTmWKKZ5smuAQbfeFE/FBYRjFmbJQpV--JKtz4i, not stripped"
+  export TARGETPLATFORM=linux/386
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit LSB executable, UCB RISC-V, version 1 (SYSV), statically linked, Go BuildID=UQcwUow8zf8eT1LVTlSd/oF4-1H5Bw_QMKx9FnmaO/CQKB2Ez22hbE9YYvWKd7/Ur6aiNESa-AIP6Ro1rJl, not stripped"
+  export TARGETPLATFORM=linux/riscv64
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit MSB executable, IBM S/390, version 1 (SYSV), statically linked, Go BuildID=qwRVuYDyb9tpvSA7lQYY/qVoTrD4RSf27VhrBT3PC/JoZWbzgRDaFm7oTKdd6z/yZwLvl0-pkyydk5jlTy-, not stripped"
+  export TARGETPLATFORM=linux/s390x
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  unset XX_VERIFY_FILE_CMD_OUTPUT
+  unset TARGETPLATFORM
+}
+
+@test "powerpc" {
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), statically linked, Go BuildID=G9tFhO-5w5V1jGY1nq03/ZBZGDzsQwa9qsqYoGAHs/iVDG5nvtXloF0ZsBbrVc/xceZ8JFoRhBEBWj-bHWq, not stripped"
+  export TARGETPLATFORM=linux/ppc64le
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=linux/ppc64
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=freebsd/ppc64le
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit MSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), statically linked, Go BuildID=NTJCtXHD7Nu0ME2rlJPD/9fIhp9NVHkc4NCQefR-5/WLWGdt9Rg5U7LQ-S5oRq/3Ntbm4FkyjDaDAcnCrR0, not stripped"
+  export TARGETPLATFORM=linux/ppc64
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=linux/ppc64le
+  run xx-verify /idontexist
+  assert_failure
+
+  unset XX_VERIFY_FILE_CMD_OUTPUT
+  unset TARGETPLATFORM
+}
+
+@test "mips" {
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit MSB executable, MIPS, MIPS-III version 1 (SYSV), statically linked, Go BuildID=77Ws5TiC_9ZYe25BIAM4/a1_qVyPawMwkNHvvV4ll/SIu3yPYvbmNdJGGtpi28/lAelXiZun7P04qEv_cbD, not stripped"
+  export TARGETPLATFORM=linux/mips64
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=linux/mips
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=freebsd/mips64le
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit LSB executable, MIPS, MIPS-III version 1 (SYSV), statically linked, Go BuildID=W27AyLn63oLqRLBKCEUh/BmXyAlBlNNBVj1GSGPWV/dCa4j32KRGxwTzCf2DYV/cgmNcrUYqSXyjQZ_AsjA, not stripped"
+  export TARGETPLATFORM=linux/mips64le
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=linux/mips64
+  run xx-verify /idontexist
+  assert_failure
+
+  unset XX_VERIFY_FILE_CMD_OUTPUT
+  unset TARGETPLATFORM
+}
+
+@test "bsd" {
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit LSB executable, x86-64, version 1 (FreeBSD), statically linked, Go BuildID=JzHsKKvTrpHA0kte6HY_/RDYVwSF6JCS9Yi-Nonvh/IVJmyepFXpNmoQZjTkjJ/bRVzwhsiIAOGiEWLblTC, not stripped"
+  export TARGETPLATFORM=freebsd/amd64
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=freebsd/arm64
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=darwin/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=netbsd/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit LSB executable, ARM aarch64, version 1 (FreeBSD), statically linked, Go BuildID=uHHgkDH8Of6DIoAgIgww/iFrsc3ZJfITXmb5sCrU1/RmnlnenMLKWBig-zBWc0/SJ8iqVFe1pByQojEwcI6, not stripped"
+  export TARGETPLATFORM=freebsd/arm64
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=freebsd/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit LSB executable, x86-64, version 1 (NetBSD), statically linked, for NetBSD 7.0, Go BuildID=r2whhMpyaCx0vBCzBIWB/PE1mEok8YniJDTokl5Yq/4x-cFXAeCQ6aBV6mHXhX/Q4W3dIg4a4DMNjZHVI6s, not stripped"
+  export TARGETPLATFORM=netbsd/amd64
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=freebsd/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export XX_VERIFY_FILE_CMD_OUTPUT=": ELF 64-bit LSB executable, x86-64, version 1 (OpenBSD), dynamically linked, interpreter /usr/libexec/ld.so, for OpenBSD, Go BuildID=HASlNvmUYcQqznD4KLzz/uWF-6ILTbaXA4vblOUhS/IvTWk7r-87qX34iKFOHl/_ZDoXMhCmv9gMSy-etK-, not stripped"
+  export TARGETPLATFORM=openbsd/amd64
+  run xx-verify /idontexist
+  assert_success
+
+  export TARGETPLATFORM=netbsd/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_failure
+
+  unset XX_VERIFY_FILE_CMD_OUTPUT
+  unset TARGETPLATFORM
+}

--- a/base/xx-verify
+++ b/base/xx-verify
@@ -90,9 +90,21 @@ for f in "$@"; do
   fi
 
   expOS=""
+  expOS2=""
   case "$TARGETOS" in
-    "linux" | "freebsd")
+    "linux" | "freebsd" | "netbsd" | "openbsd")
       expOS="ELF"
+      case "$TARGETOS" in
+        "freebsd")
+          expOS2="(FreeBSD)"
+          ;;
+        "netbsd")
+          expOS2="(NetBSD)"
+          ;;
+        "openbsd")
+          expOS2="(OpenBSD)"
+          ;;
+      esac
       ;;
     "darwin")
       expOS="Mach-O"
@@ -112,47 +124,69 @@ for f in "$@"; do
     exit 1
   fi
 
+  if [ -n "$expOS2" ]; then
+    if ! echo "$out" | grep "$expOS2" >/dev/null; then
+      echo >&2 "file ${f} does not match expected target OS ${TARGETOS}: $out"
+      exit 1
+    fi
+  fi
+
+  if [ "linux" = "$TARGETOS" ]; then
+    if echo "$out" | grep -E "FreeBSD|NetBSD|OpenBSD" >/dev/null; then
+      echo >&2 "file ${f} does not match expected target OS ${TARGETOS}: $out"
+      exit 1
+    fi
+  fi
+
   expArch=""
   expArch2="" # extra check for endianness
   case "$TARGETARCH" in
     "arm64")
       case "$TARGETOS" in
-        "linux" | "freebsd")
-          expArch="ARM aarch64"
-          expArch2="64-bit LSB"
-          ;;
         "darwin")
           expArch="arm64"
           ;;
         "windows")
           expArch="Aarch64"
           ;;
+        *)
+          expArch="ARM aarch64"
+          expArch2="64-bit LSB"
+          ;;
       esac
       ;;
     "amd64")
       case "$TARGETOS" in
-        "linux" | "freebsd")
-          expArch="x86-64"
-          expArch2="64-bit LSB"
-          ;;
         "darwin")
           expArch="x86_64"
           ;;
         "windows")
           expArch="x86-64"
           ;;
+        *)
+          expArch="x86-64"
+          expArch2="64-bit LSB"
+          ;;
       esac
       ;;
     "arm")
       case "$TARGETOS" in
-        "linux" | "freebsd")
-          expArch="ARM,"
-          expArch2="32-bit LSB"
-          ;;
         "windows")
           expArch="ARMv7"
           ;;
+        *)
+          expArch="ARM,"
+          expArch2="32-bit LSB"
+          ;;
       esac
+      ;;
+    "armbe")
+      expArch="ARM,"
+      expArch2="32-bit MSB"
+      ;;
+    "arm64be")
+      expArch="ARM aarch64"
+      expArch2="64-bit MSB"
       ;;
     "riscv64")
       expArch="RISC-V"
@@ -161,6 +195,10 @@ for f in "$@"; do
     "ppc64le")
       expArch="64-bit PowerPC"
       expArch2="64-bit LSB"
+      ;;
+    "ppc64")
+      expArch="64-bit PowerPC"
+      expArch2="64-bit MSB"
       ;;
     "s390x")
       expArch="IBM S/390"


### PR DESCRIPTION
supersedes #47 

This adds more test conditions based on the expected output logic that was added in #26 . Also fixes/adds some cases for BSD variants and some uncommon architectures. 

@akhramov Compared to #47 I noticed that binaries produced by go do not have "FreeBSD-style" in output. I didn't dig into what is the difference but just checking for "FreeBSD" seems good enough for our cases. PTAL

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>