### PR TITLE
apt: fix package check

### DIFF
--- a/base/test-apt.bats
+++ b/base/test-apt.bats
@@ -203,3 +203,10 @@ load 'assert'
   unset TARGETOS
   unset TARGETARCH
 }
+
+@test "checkpkg" {
+  run apt show wget
+  assert_success
+  run apt show wget-notexist
+  assert_failure
+}

--- a/base/xx-apt
+++ b/base/xx-apt
@@ -17,6 +17,10 @@ for l in $(xx-info env); do
   export "${l?}"
 done
 
+checkpkg() {
+  apt show "$@"
+}
+
 if [ "${TARGETOS}" != "linux" ]; then
   echo >&2 "skipping packages installation on ${XX_OS}"
   exit 0
@@ -128,9 +132,9 @@ for p in ${packages2}; do
   n=
   if [ -n "$nocross" ]; then
     n=${p}
-  elif "$arg0" info "${p}-${suffix}" >/dev/null 2>/dev/null; then
+  elif checkpkg "${p}-${suffix}" >/dev/null 2>/dev/null; then
     n="${p}-${suffix}"
-  elif [ -n "${XX_APT_PREFER_CROSS}" ] && apt info "${p}-${XX_PKG_ARCH}-cross" >/dev/null 2>/dev/null; then
+  elif [ -n "${XX_APT_PREFER_CROSS}" ] && checkpkg "${p}-${XX_PKG_ARCH}-cross" >/dev/null 2>/dev/null; then
     n="${p}-${XX_PKG_ARCH}-cross"
   else
     n="${p}:${XX_PKG_ARCH}"


### PR DESCRIPTION
`apt-get info` does not exist and `apt info` is missing in ubuntu 18.04

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>