### PR TITLE
xx-info: handle rhel arch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,10 @@ jobs:
             image: debian:sid
             typ: debian
             allow-failure: true
+          -
+            image: fedora:35
+            typ: rhel
+            allow-failure: false
     steps:
       -
         name: Checkout

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ These commands return architecture names as used by specific tools to avoid conv
 - `xx-info march` - Target machine architecture that is expected to match value of `uname -m`
 - `xx-info alpine-arch`  - Target architecture for [Alpine package repositories](https://pkgs.alpinelinux.org/packages)
 - `xx-info debian-arch` - Target architecture for [Debian package repositories](https://www.debian.org/ports/)
-- `xx-info pkg-arch` - Either alpine-arch or debian-arch depending on the context
+- `xx-info rhel-arch` - Target architecture for [RPM package repositories](https://docs.fedoraproject.org/ro/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch01s03.html)
+- `xx-info pkg-arch` - Either alpine-arch, debian-arch or rhel-arch depending on the context
 
 #### Target triple
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -32,6 +32,12 @@ RUN --mount=type=cache,target=/pkg-cache \
     apt update && apt install --no-install-recommends -y bats vim
 WORKDIR /work
 
+FROM ${TEST_BASE_IMAGE} AS test-base-rhel
+RUN --mount=type=cache,target=/pkg-cache \
+    rm -rf /var/cache/yum && \
+    ln -s /pkg-cache /var/cache/yum && \
+    yum -y install bats vim
+WORKDIR /work
 
 FROM test-base-${TEST_BASE_TYPE} AS test
 COPY --from=assert . .

--- a/base/test-info-rhel.bats
+++ b/base/test-info-rhel.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+load "assert"
+
+@test "vendor" {
+  assert_equal "fedora" "$(xx-info vendor)"
+}
+
+@test "rhel-arch" {
+  assert_equal "$(xx-info rhel-arch)" "$(xx-info pkg-arch)"
+}
+
+@test "amd64" {
+  assert_equal "x86_64" "$(TARGETPLATFORM=linux/amd64 xx-info pkg-arch)"
+}
+
+@test "aarch64" {
+  assert_equal "aarch64" "$(TARGETPLATFORM=linux/arm64 xx-info pkg-arch)"
+}
+
+@test "arm" {
+  assert_equal "armv7hl" "$(TARGETPLATFORM=linux/arm xx-info pkg-arch)"
+}
+
+@test "armv6" {
+  assert_equal "armv6hl" "$(TARGETPLATFORM=linux/arm/v6 xx-info pkg-arch)"
+}
+
+@test "armv5" {
+  assert_equal "armv5tel" "$(TARGETPLATFORM=linux/arm/v5 xx-info pkg-arch)"
+}
+
+@test "386" {
+  assert_equal "i386" "$(TARGETPLATFORM=linux/386 xx-info pkg-arch)"
+}
+
+@test "ppc64le" {
+  assert_equal "ppc64le" "$(TARGETPLATFORM=linux/ppc64le xx-info pkg-arch)"
+}
+
+@test "s390x" {
+  assert_equal "s390x" "$(TARGETPLATFORM=linux/s390x xx-info pkg-arch)"
+}
+
+@test "riscv64" {
+  assert_equal "riscv64" "$(TARGETPLATFORM=linux/riscv64 xx-info pkg-arch)"
+}

--- a/base/xx-info
+++ b/base/xx-info
@@ -11,6 +11,8 @@
 : "${XX_ALPINE_ARCH=unknown}"
 # https://www.debian.org/ports/
 : "${XX_DEBIAN_ARCH=unknown}"
+# https://docs.fedoraproject.org/ro/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch01s03.html
+: "${XX_RHEL_ARCH=unknown}"
 : "${XX_TRIPLE=unknown-unknown-none}"
 : "${XX_VENDOR=unknown}"
 : "${XX_LIBC=}"
@@ -29,6 +31,7 @@ Commands:
   march          Print target machine architecture, uname -m
   os             Print target operating system (linux,darwin,windows,wasi)
   pkg-arch       Print either alpine-arch or debian-arch
+  rhel-arch      Print target architecture for RPM package repositories
   sysroot        Print sysroot directory for target architecture
   triple         Print target triple in arch[-vendor]-os-abi form
   vendor         Print vendor part of target triple
@@ -107,7 +110,7 @@ fi
 
 vendor=""
 
-if [ "$XX_VENDOR" != "unknown" ] && [ "$XX_VENDOR" != "debian" ]; then
+if [ "$XX_VENDOR" != "unknown" ] && [ "$XX_VENDOR" != "debian" ] && [ "$XX_VENDOR" != "rhel" ] && [ "$XX_VENDOR" != "fedora" ] && [ "$XX_VENDOR" != "centos" ] && [ "$XX_VENDOR" != "rocky" ]; then
   vendor="-${XX_VENDOR}"
 fi
 
@@ -182,6 +185,7 @@ case "$TARGETARCH" in
     XX_MARCH="x86_64"
     XX_DEBIAN_ARCH="amd64"
     XX_ALPINE_ARCH="x86_64"
+    XX_RHEL_ARCH="x86_64"
     XX_TRIPLE="x86_64${vendor}-linux-${XX_LIBC}"
     if [ "$TARGETOS" = "darwin" ]; then
       XX_TRIPLE="x86_64${vendor}-macos${MACOSX_VERSION_MIN}"
@@ -193,6 +197,7 @@ case "$TARGETARCH" in
     XX_MARCH="aarch64"
     XX_DEBIAN_ARCH="arm64"
     XX_ALPINE_ARCH="aarch64"
+    XX_RHEL_ARCH="aarch64"
     XX_TRIPLE="aarch64${vendor}-linux-${XX_LIBC}"
     if [ "$TARGETOS" = "darwin" ]; then
       XX_MARCH="arm64"
@@ -205,6 +210,7 @@ case "$TARGETARCH" in
     XX_MARCH="armv7l"
     XX_DEBIAN_ARCH="armhf"
     XX_ALPINE_ARCH="armv7"
+    XX_RHEL_ARCH="armv7hl"
     XX_TRIPLE="arm${vendor}-linux-${XX_LIBC}eabihf"
     if [ "$XX_VENDOR" = "alpine" ]; then
       XX_TRIPLE="armv7${vendor}-linux-${XX_LIBC}eabihf"
@@ -213,6 +219,7 @@ case "$TARGETARCH" in
       XX_MARCH="armv6l"
       XX_DEBIAN_ARCH="armel"
       XX_ALPINE_ARCH="armhf"
+      XX_RHEL_ARCH="armv6hl"
       XX_TRIPLE="arm${vendor}-linux-${XX_LIBC}eabi"
       if [ "$XX_VENDOR" = "alpine" ]; then
         XX_TRIPLE="armv6${vendor}-linux-${XX_LIBC}eabihf"
@@ -222,6 +229,7 @@ case "$TARGETARCH" in
       XX_MARCH="armv5l"
       XX_DEBIAN_ARCH="armel"
       XX_ALPINE_ARCH="armel" # alpine does not actually support v5
+      XX_RHEL_ARCH="armv5tel"
       XX_TRIPLE="arm${vendor}-linux-${XX_LIBC}eabi"
       if [ "$XX_VENDOR" = "alpine" ]; then
         XX_TRIPLE="armv5${vendor}-linux-${XX_LIBC}eabi"
@@ -236,24 +244,28 @@ case "$TARGETARCH" in
     XX_MARCH="riscv64"
     XX_DEBIAN_ARCH="riscv64"
     XX_ALPINE_ARCH="riscv64"
+    XX_RHEL_ARCH="riscv64"
     XX_TRIPLE="riscv64${vendor}-linux-${XX_LIBC}"
     ;;
   "ppc64le")
     XX_MARCH="ppc64le"
     XX_DEBIAN_ARCH="ppc64el"
     XX_ALPINE_ARCH="ppc64le"
+    XX_RHEL_ARCH="ppc64le"
     XX_TRIPLE="powerpc64le${vendor}-linux-${XX_LIBC}"
     ;;
   "s390x")
     XX_MARCH="s390x"
     XX_DEBIAN_ARCH="s390x"
     XX_ALPINE_ARCH="s390x"
+    XX_RHEL_ARCH="s390x"
     XX_TRIPLE="s390x${vendor}-linux-${XX_LIBC}"
     ;;
   "386")
     XX_MARCH="i386"
     XX_DEBIAN_ARCH="i386"
     XX_ALPINE_ARCH="x86"
+    XX_RHEL_ARCH="i386"
     XX_TRIPLE="i686${vendor}-linux-${XX_LIBC}"
     if [ "$XX_VENDOR" = "alpine" ]; then
       XX_TRIPLE="i586${vendor}-linux-${XX_LIBC}"
@@ -269,6 +281,8 @@ if [ "$XX_VENDOR" = "debian" ]; then
   XX_PKG_ARCH=${XX_DEBIAN_ARCH}
 elif [ "$XX_VENDOR" = "alpine" ]; then
   XX_PKG_ARCH=${XX_ALPINE_ARCH}
+elif [ "$XX_VENDOR" = "rhel" ] || [ "$XX_VENDOR" = "fedora" ] || [ "$XX_VENDOR" = "centos" ] || [ "$XX_VENDOR" = "rocky" ]; then
+  XX_PKG_ARCH=${XX_RHEL_ARCH}
 fi
 
 case "$1" in
@@ -296,6 +310,9 @@ case "$1" in
     ;;
   "alpine-arch")
     echo $XX_ALPINE_ARCH
+    ;;
+  "rhel-arch")
+    echo $XX_RHEL_ARCH
     ;;
   "pkg-arch")
     echo $XX_PKG_ARCH

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -8,7 +8,7 @@ target "meta-helper" {
 }
 
 group "test" {
-    targets = ["test-alpine", "test-debian"]
+    targets = ["test-alpine", "test-debian", "test-rhel"]
 }
 
 target "test-base" {
@@ -25,6 +25,15 @@ target "test-debian" {
     args = {
         TEST_BASE_TYPE = "debian"
         TEST_BASE_IMAGE = "debian:bullseye"
+    }
+}
+
+target "test-rhel" {
+    inherits = ["test-base"]
+    args = {
+        TEST_BASE_TYPE = "rhel"
+        TEST_BASE_IMAGE = "fedora:35"
+        TEST_CMDS = "info"
     }
 }
 


### PR DESCRIPTION
Handle RHEL based distrib for `xx-info`. This is partially needed for https://github.com/docker/buildx/pull/840 to handle RPM arch package properly. Following distribs are currently handled:

```
$ docker run --rm -it fedora:35 cat /etc/os-release
NAME="Fedora Linux"
VERSION="35 (Container Image)"
ID=fedora
VERSION_ID=35
VERSION_CODENAME=""
PLATFORM_ID="platform:f35"
PRETTY_NAME="Fedora Linux 35 (Container Image)"
ANSI_COLOR="0;38;2;60;110;180"
LOGO=fedora-logo-icon
CPE_NAME="cpe:/o:fedoraproject:fedora:35"
HOME_URL="https://fedoraproject.org/"
DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/f35/system-administrators-guide/"
SUPPORT_URL="https://ask.fedoraproject.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Fedora"
REDHAT_BUGZILLA_PRODUCT_VERSION=35
REDHAT_SUPPORT_PRODUCT="Fedora"
REDHAT_SUPPORT_PRODUCT_VERSION=35
PRIVACY_POLICY_URL="https://fedoraproject.org/wiki/Legal:PrivacyPolicy"
VARIANT="Container Image"
VARIANT_ID=container
```

```
$ docker run --rm -it centos:8 cat /etc/os-release
NAME="CentOS Linux"
VERSION="8"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="8"
PLATFORM_ID="platform:el8"
PRETTY_NAME="CentOS Linux 8"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:8"
HOME_URL="https://centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"
CENTOS_MANTISBT_PROJECT="CentOS-8"
CENTOS_MANTISBT_PROJECT_VERSION="8"
```

```
$ docker run --rm -it rockylinux/rockylinux cat /etc/os-release
NAME="Rocky Linux"
VERSION="8.4 (Green Obsidian)"
ID="rocky"
ID_LIKE="rhel fedora"
VERSION_ID="8.4"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Rocky Linux 8.4 (Green Obsidian)"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:rocky:rocky:8.4:GA"
HOME_URL="https://rockylinux.org/"
BUG_REPORT_URL="https://bugs.rockylinux.org/"
ROCKY_SUPPORT_PRODUCT="Rocky Linux"
ROCKY_SUPPORT_PRODUCT_VERSION="8"
```

```
$ docker run --rm -it redhat/ubi8 cat /etc/os-release
NAME="Red Hat Enterprise Linux"
VERSION="8.5 (Ootpa)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="8.5"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Red Hat Enterprise Linux 8.5 (Ootpa)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:8::baseos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/red_hat_enterprise_linux/8/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
REDHAT_BUGZILLA_PRODUCT_VERSION=8.5
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="8.5"
```

I wonder if we should not take into account `ID_LIKE` to properly handle RHEL based distrib. Same could be done for Debian based in #49.

In a follow-up we could start thinking about `xx-yum`.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>