### PR TITLE
xx-info: oracle linux support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,16 +60,32 @@ jobs:
             typ: debian
             allow-failure: true
           -
-            image: fedora:35
-            typ: rhel
-            allow-failure: false
-          -
             image: ubuntu:20.04
             typ: debian
             allow-failure: false
           -
             image: ubuntu:21.10
             typ: debian
+            allow-failure: false
+          -
+            image: redhat/ubi8
+            typ: rhel
+            allow-failure: false
+          -
+            image: fedora:35
+            typ: rhel
+            allow-failure: false
+          -
+            image: centos:8
+            typ: rhel
+            allow-failure: false
+          -
+            image: rockylinux/rockylinux:8
+            typ: rhel
+            allow-failure: false
+          -
+            image: oraclelinux:8
+            typ: rhel
             allow-failure: false
     steps:
       -

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,5 @@
-#syntax=docker/dockerfile:1.2
+# syntax=docker/dockerfile:1.3-labs
+
 ARG TEST_BASE_TYPE=alpine
 ARG TEST_BASE_IMAGE=${TEST_BASE_TYPE}
 ARG TEST_WITH_DARWIN=false
@@ -33,6 +34,16 @@ RUN --mount=type=cache,target=/pkg-cache \
 WORKDIR /work
 
 FROM ${TEST_BASE_IMAGE} AS test-base-rhel
+RUN <<EOT
+set -ex
+if ! yum install -y epel-release; then
+  if . /etc/os-release 2>/dev/null; then
+    if [ "$ID" != "fedora" ]; then
+      yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-${VERSION:0:1}.noarch.rpm
+    fi
+  fi
+fi
+EOT
 RUN --mount=type=cache,target=/pkg-cache \
     rm -rf /var/cache/yum && \
     ln -s /pkg-cache /var/cache/yum && \

--- a/base/test-info-rhel.bats
+++ b/base/test-info-rhel.bats
@@ -2,8 +2,19 @@
 
 load "assert"
 
+vendor="rhel"
+if grep </etc/redhat-release "Fedora" 2>/dev/null >/dev/null; then
+  vendor="fedora"
+elif grep </etc/redhat-release "CentOS" 2>/dev/null >/dev/null; then
+  vendor="centos"
+elif grep </etc/redhat-release "Rocky Linux" 2>/dev/null >/dev/null; then
+  vendor="rocky"
+elif [ -f /etc/oracle-release ] && grep </etc/oracle-release "Oracle Linux" 2>/dev/null >/dev/null; then
+  vendor="ol"
+fi
+
 @test "vendor" {
-  assert_equal "fedora" "$(xx-info vendor)"
+  assert_equal "$vendor" "$(xx-info vendor)"
 }
 
 @test "rhel-arch" {

--- a/base/xx-info
+++ b/base/xx-info
@@ -110,7 +110,7 @@ fi
 
 vendor=""
 
-if [ "$XX_VENDOR" != "unknown" ] && [ "$XX_VENDOR" != "debian" ] && [ "$XX_VENDOR" != "rhel" ] && [ "$XX_VENDOR" != "fedora" ] && [ "$XX_VENDOR" != "centos" ] && [ "$XX_VENDOR" != "rocky" ] && [ "$XX_VENDOR" != "ubuntu" ]; then
+if [ "$XX_VENDOR" != "unknown" ] && [ "$XX_VENDOR" != "debian" ] && [ "$XX_VENDOR" != "ubuntu" ] && [ "$XX_VENDOR" != "rhel" ] && [ "$XX_VENDOR" != "fedora" ] && [ "$XX_VENDOR" != "centos" ] && [ "$XX_VENDOR" != "rocky" ] && [ "$XX_VENDOR" != "ol" ]; then
   vendor="-${XX_VENDOR}"
 fi
 
@@ -281,7 +281,7 @@ if [ "$XX_VENDOR" = "debian" ] || [ "$XX_VENDOR" = "ubuntu" ]; then
   XX_PKG_ARCH=${XX_DEBIAN_ARCH}
 elif [ "$XX_VENDOR" = "alpine" ]; then
   XX_PKG_ARCH=${XX_ALPINE_ARCH}
-elif [ "$XX_VENDOR" = "rhel" ] || [ "$XX_VENDOR" = "fedora" ] || [ "$XX_VENDOR" = "centos" ] || [ "$XX_VENDOR" = "rocky" ]; then
+elif [ "$XX_VENDOR" = "rhel" ] || [ "$XX_VENDOR" = "fedora" ] || [ "$XX_VENDOR" = "centos" ] || [ "$XX_VENDOR" = "rocky" ] || [ "$XX_VENDOR" = "ol" ]; then
   XX_PKG_ARCH=${XX_RHEL_ARCH}
 fi
 


### PR DESCRIPTION
follow-up #52 with oracle linux support that was missing

second commit add tests against currently supported rhel distribs (just xx-info test atm)