### PR TITLE
xx-apk: add rules for compiler-rt

### DIFF
--- a/base/xx-apk
+++ b/base/xx-apk
@@ -81,6 +81,7 @@ cmd() {
     root="/${XX_TRIPLE}"
   fi
   n=$#
+  iscompilerrt=
   for a in "$@"; do
     if [ $# = $n ]; then set --; fi
     case "$a" in
@@ -89,6 +90,10 @@ cmd() {
         ;;
       "xx-cxx-essentials")
         set -- "$@" g++
+        ;;
+      "compiler-rt" | "compiler-rt-static")
+        iscompilerrt=1
+        set -- "$@" "$a"
         ;;
       *)
         set -- "$@" "$a"
@@ -103,6 +108,16 @@ cmd() {
   if xx-info is-cross; then
     if [ -z "$XX_APK_KEEP_BINARIES" ]; then
       rm -rf "/${XX_TRIPLE:?}/usr/bin/*"
+    fi
+    if [ -n "$iscompilerrt" ]; then
+      # shellcheck disable=SC2044
+      for f in $(find /"$(xx-info)"/usr/lib/clang -type f -name "*clang_rt.*"); do
+        ff=${f#/$(xx-info)}
+        if [ ! -f "${ff}" ]; then
+          mkdir -p "$(dirname "${ff}")"
+          ln -s "$f" "${ff}"
+        fi
+      done
     fi
   fi
 }


### PR DESCRIPTION
Enables `--rtlib=compiler-rt` instead of installing `gcc` for libgcc libs.

Not sure how to achieve similar for debian/ubuntu atm. The files exist in `libclang-common-dev` but library can't be installed at the same time as `clang`. Possibly only solution is to revive our own build https://github.com/tonistiigi/xx/blob/b7c9c0be7c06c901d84e223382b4e460a1f20fec/base/Dockerfile#L345 .

We could also extend `xx-clang` to detect when compiler-rt is installed and default `--rtlib`.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>