### PR TITLE
ci: centos 8 eol, use centos 7 instead

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
             typ: rhel
             allow-failure: false
           -
-            image: centos:8
+            image: centos:7
             typ: rhel
             allow-failure: false
           -


### PR DESCRIPTION
encounter the following issue in #64: https://github.com/tonistiigi/xx/runs/6196721054?check_suite_focus=true#step:3:238

```
#0 1.003 + . /etc/os-release
#0 1.004 + '[' centos '!=' fedora ']'
#0 1.004 + yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
#0 1.454 CentOS Linux 8 - AppStream                      232  B/s |  38  B     00:00    
#0 1.458 Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
```

the current official Docker image `centos:8` is a CentOS 8 that is EOL since December 2021 and epel release repo now uses CentOS Stream 8 which is not compatible.

I don't see any CentOS Stream 8 official image atm so switch to CentOS 7 (maintained until 2024) in our ci matrix.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>