### PR TITLE
test-clang: chmod missing

### DIFF
--- a/base/test-clang.bats
+++ b/base/test-clang.bats
@@ -170,6 +170,7 @@ testBuildHello() {
   export TARGETPLATFORM="linux/ppc64le"
 
   touch /usr/bin/$(xx-info triple)-ld
+  chmod +x /usr/bin/$(xx-info triple)-ld
 
   run xx-clang --setup-target-triple
   assert_success


### PR DESCRIPTION
follow-up https://github.com/tonistiigi/xx/pull/65#issuecomment-1111184217

looks like since bookworm `command` requires file to have execute permission.

test fails here https://github.com/tonistiigi/xx/blob/6bf9570dbd748abf5ed47c6366ce4828da258912/base/test-clang.bats#L174 because `command` not valid in https://github.com/tonistiigi/xx/blob/6bf9570dbd748abf5ed47c6366ce4828da258912/base/xx-cc#L454

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>