### PR TITLE
ci: os update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,10 @@ jobs:
             typ: alpine
             allow-failure: false
           -
+            image: alpine:3.16
+            typ: alpine
+            allow-failure: false
+          -
             image: alpine:edge
             typ: alpine
             allow-failure: true
@@ -68,7 +72,7 @@ jobs:
             typ: debian
             allow-failure: false
           -
-            image: ubuntu:21.10
+            image: ubuntu:22.04
             typ: debian
             allow-failure: false
           -
@@ -77,6 +81,10 @@ jobs:
             allow-failure: false
           -
             image: fedora:35
+            typ: rhel
+            allow-failure: false
+          -
+            image: fedora:36
             typ: rhel
             allow-failure: false
           -
@@ -95,6 +103,12 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       -
         name: Test
         uses: docker/bake-action@v1

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -25,11 +25,15 @@ RUN --mount=type=cache,target=/pkg-cache \
 WORKDIR /work
 
 FROM ${TEST_BASE_IMAGE} AS test-base-debian
+ARG APT_MIRROR=deb.debian.org
 RUN --mount=type=cache,target=/pkg-cache \
     rm -rf /var/cache/apt/archives && \
     ln -s /pkg-cache /var/cache/apt/archives && \
     rm /etc/apt/apt.conf.d/docker-clean && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "1";' > /etc/apt/apt.conf.d/keep-downloads && \
+    touch /etc/apt/sources.list && \
+    sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list && \
+    sed -ri "s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g" /etc/apt/sources.list && \
     apt update && apt install --no-install-recommends -y bats vim
 WORKDIR /work
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -23,6 +23,7 @@ target "test-alpine" {
 target "test-debian" {
     inherits = ["test-base"]
     args = {
+        APT_MIRROR = "cdn-fastly.deb.debian.org"
         TEST_BASE_TYPE = "debian"
         TEST_BASE_IMAGE = "debian:bullseye"
     }


### PR DESCRIPTION
* `alpine 3.16`
* `fedora 36`
* `ubuntu 22.04`

removes `ubuntu 21.10` (eol since July 14, 2022) that fails in our pipeline: https://github.com/tonistiigi/xx/runs/7837299244?check_suite_focus=true#step:3:242

```
 > [test-base-debian 2/3] RUN --mount=type=cache,target=/pkg-cache     rm -rf /var/cache/apt/archives &&     ln -s /pkg-cache /var/cache/apt/archives &&     rm /etc/apt/apt.conf.d/docker-clean &&     echo 'Binary::apt::APT::Keep-Downloaded-Packages "1";' > /etc/apt/apt.conf.d/keep-downloads &&     apt update && apt install --no-install-recommends -y bats vim:
#19 0.696   404  Not Found [IP: 185.125.190.36 80]
#19 0.771 Err:7 http://archive.ubuntu.com/ubuntu impish-updates Release
#19 0.771   404  Not Found [IP: 185.125.190.36 80]
#19 0.847 Err:8 http://archive.ubuntu.com/ubuntu impish-backports Release
#19 0.847   404  Not Found [IP: 185.125.190.36 80]
#19 0.848 Reading package lists...
#19 0.860 E: The repository 'http://security.ubuntu.com/ubuntu impish-security Release' does not have a Release file.
#19 0.860 E: The repository 'http://archive.ubuntu.com/ubuntu impish Release' does not have a Release file.
#19 0.860 E: The repository 'http://archive.ubuntu.com/ubuntu impish-updates Release' does not have a Release file.
#19 0.860 E: The repository 'http://archive.ubuntu.com/ubuntu impish-backports Release' does not have a Release file.
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>