### PR TITLE
ci: allow failure for bookworm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,8 @@ jobs:
           -
             image: debian:bookworm
             typ: debian
-            allow-failure: false
+            # FIXME: Set to false when https://github.com/tonistiigi/xx/issues/95 fixed
+            allow-failure: true
           -
             image: debian:sid
             typ: debian


### PR DESCRIPTION
Needs to allow failure for test on bookworm while waiting for https://github.com/tonistiigi/xx/issues/95 to be fixed, otherwise we can't do a release.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>