### PR TITLE
xx-cc: update prebuilt ld to binutils 2.38

### DIFF
--- a/base/xx-cc
+++ b/base/xx-cc
@@ -2,7 +2,7 @@
 
 set -e
 
-mirrors="https://github.com/tonistiigi/xx/releases/download/prebuilt%2Fld-1"
+mirrors="https://github.com/tonistiigi/xx/releases/download/prebuilt%2Fld-2.38-0"
 
 if [ -n "$XX_MIRROR" ]; then
   mirrors="$XX_MIRROR"
@@ -194,11 +194,11 @@ download_ld64() {
   ensurewget
   shas=$(
     cat <<'EOT'
-ld64-signed-linux-386 7b664761928f6d5dd8d505e533b45e67a86ff1d4
-ld64-signed-linux-amd64 a218662887a1c9daf94a57fb4569455315f8ef7f
-ld64-signed-linux-arm64 3257520368b3e32fa1b413151c79f75bd0c77bed
-ld64-signed-linux-armv6 df770289f82a1ce50fd069cef48a3e79185bd508
-ld64-signed-linux-armv7 1dbf5be507a73768bb1ee72d3325020640cca614
+ld64-signed-linux-386 b60f72fb81845f707786cee499f49541a1c46686
+ld64-signed-linux-amd64 2dd147c0b50f83e7939c7fa151fe81febae84caf
+ld64-signed-linux-arm64 89125aa156c77a772d05b3d02a183b446b20c5b8
+ld64-signed-linux-armv6 ce1744dfaff44ffacf57e77994e3a8b2eedffe8a
+ld64-signed-linux-armv7 93314800a42f36e2d2a90c99e7c1f7ac7e6f43fb
 EOT
   )
 
@@ -245,76 +245,76 @@ download_ld() {
   # for f in *; do echo -n "${f%.tar.gz} " ; shasum -a 1 -b $f | cut -d' ' -f1 ; done | pbcopy
   shas=$(
     cat <<'EOT'
-linux-386-ld-linux-386 f26c1d9bdefe3c139db91f1f02369a897db1a682
-linux-386-ld-linux-amd64 1bbb8c30de5855ed183ba5e1799d46da66f18525
-linux-386-ld-linux-arm64 8fe1e78d15e0835272025de3cd14b1d863038e0b
-linux-386-ld-linux-armv6 0b6fdc84037e2d20057ef4c3d567989b4ce588b1
-linux-386-ld-linux-armv7 a860b73e473f3596a9166462a8e279d871e1596b
-linux-386-ld-linux-ppc64le 359cbcf078111430e42654e06a06817384d08f1c
-linux-386-ld-linux-s390x fc63fe0ad012ac5ed8d5423b8d40e709ed690da7
-linux-amd64-ld-linux-386 7211f566acb3bf43e3cf5b0e89583203d14e00b5
-linux-amd64-ld-linux-amd64 00b702ae772948804f222996f15ba9dc3def8d9f
-linux-amd64-ld-linux-arm64 67f3be9f050435699bfe1edfdf9e6fed569afd56
-linux-amd64-ld-linux-armv6 97e9ed3e0f20a69e913fca5495a00429abf53204
-linux-amd64-ld-linux-armv7 0218d6fed88fc5e0b7ec3241b8ba22bf694dc861
-linux-amd64-ld-linux-ppc64le 851638910f930390a6e28ff32f05f8a7a1424a33
-linux-amd64-ld-linux-s390x 9fd10cc922d78e781fb57969b642f82262f5b9b6
-linux-arm64-ld-linux-386 67ed0a1c166895b5bc69746a4d46462c66433f1f
-linux-arm64-ld-linux-amd64 63d9ea9166dd42015ed0b88258dded7800ba0991
-linux-arm64-ld-linux-arm64 f87a87bd6cd2fdba224656fecea8b87ebe4e06df
-linux-arm64-ld-linux-armv6 d5afd182c57bfd49e7543c4690dd4562487c1bb2
-linux-arm64-ld-linux-armv7 146c11f8f51034fed91c4462cb56f042dfd8f6ee
-linux-arm64-ld-linux-ppc64le 32440a9eb9fee7ae7979e91f029456af14fe77bc
-linux-arm64-ld-linux-s390x 2d8b144a7c662d32517130bbd479a1ba950d4021
-linux-armv6-ld-linux-386 8f1412fa81afd382c5bf37ccbeee9933120e4e24
-linux-armv6-ld-linux-amd64 bc9191dd462119e7561366be0903d5aa80182745
-linux-armv6-ld-linux-arm64 9b8cc4996ab5f7ad7981632c3b80e56a81841632
-linux-armv6-ld-linux-armv6 4aa7d4981c1ca62ffe95c3b822508ffbc915bfd4
-linux-armv6-ld-linux-armv7 c60bd68a5229fb9c6edabc74f75e569d67a8c191
-linux-armv6-ld-linux-ppc64le 05f7220c713c57ebda9cfae674685cce1efd15eb
-linux-armv6-ld-linux-s390x 6f16aa712e04200635bee2a18221bc2b53b5367f
-linux-armv7-ld-linux-386 dc7b03f32f7b62117af7b158f8918194821ed70c
-linux-armv7-ld-linux-amd64 20b59e08b60214d4ac7f9c552802412347e4cb0b
-linux-armv7-ld-linux-arm64 fbdff9ab4676e6a4abd4462f93031a8f2043bf0e
-linux-armv7-ld-linux-armv6 9e91f0a25b816342a4241d722ca36bfec9c9cf97
-linux-armv7-ld-linux-armv7 c2f0dcbdd2afe320f2c93b8aa5f9214f692b439e
-linux-armv7-ld-linux-ppc64le 52b0c279025b147ca5f8c9a9795e636bdf02632b
-linux-armv7-ld-linux-s390x a9544446c0890c961f53c0dadc43784eca406f0a
-linux-ppc64le-ld-linux-386 93c90d7a14407e9e17cadcdcb695b833187fcdb4
-linux-ppc64le-ld-linux-amd64 c90cdfb51bf6e439c273b5867518ad5e9c6dd371
-linux-ppc64le-ld-linux-arm64 b58ed9a8bb7287a558d0027d1c5901a14f9214fb
-linux-ppc64le-ld-linux-armv6 0c4635be4d2df4010213babc4b194b5b4148716b
-linux-ppc64le-ld-linux-armv7 15c7b36d0df188081e00ecdc3297eb14093b255f
-linux-ppc64le-ld-linux-ppc64le f48781830bce5e87f814fe3bf480ea349d019d89
-linux-ppc64le-ld-linux-s390x 72ec84b9a73904555aa56490fc8acf37813b397e
-linux-riscv64-ld-linux-386 0028e50478b516f8e97640d48329cc3dca4d1aef
-linux-riscv64-ld-linux-amd64 3f1a6c377fd37b0bd20cee2d5de0dd2594652b91
-linux-riscv64-ld-linux-arm64 2be29a72197846ccaba24832ecf99cf9df1db2b2
-linux-riscv64-ld-linux-armv6 f88badee63c0ecaecb7d807cc65586bf5711bb13
-linux-riscv64-ld-linux-armv7 6d8cbb17d3fc71e48001566f3ef4895f2f680b81
-linux-riscv64-ld-linux-ppc64le 9fa253d83d4f46c39fd141d551c0d2b211c8826c
-linux-riscv64-ld-linux-s390x c17ebba5f0742fb78d39fb65288f851a3652dd90
-linux-s390x-ld-linux-386 e6d6b1ac10b726cc6d57efe7900e40131295d446
-linux-s390x-ld-linux-amd64 f7d1e1a0a0dbf6bdb64e3da253e6ca843d42a683
-linux-s390x-ld-linux-arm64 490d359bf81c8d338e8fced61f9185e516e3bf7a
-linux-s390x-ld-linux-armv6 dc2c3c584fbf0e31b227c26436b6a3bb2fa6f58d
-linux-s390x-ld-linux-armv7 de9a38da06d6c08f411b85fd7e81ce20c3b6c956
-linux-s390x-ld-linux-ppc64le 09f74ed0bfbc97f38e5ef9c8885f19cceedfeb11
-linux-s390x-ld-linux-s390x 3e882ae2edaf06f5ae0900d16cd456516f710482
-windows-386-ld-linux-386 6519bb906421c76df6432c0f9a324759f7a89799
-windows-386-ld-linux-amd64 b7c26a07cb1811808c9b51bcab11718aa73fc3d0
-windows-386-ld-linux-arm64 7d218748f9608e580cf0718a0286de5803cc7148
-windows-386-ld-linux-armv6 656ecf7ccfcf8815f541abb1c812659c93828d79
-windows-386-ld-linux-armv7 73b2e3414932b3d6e18db6eb717078f08b705543
-windows-386-ld-linux-ppc64le e259fd1b96e1403b669538bc5769a15c9dc4e5a0
-windows-386-ld-linux-s390x 035ccf00fbc7d283c25f34c189cdac85f819ed5e
-windows-amd64-ld-linux-386 2a82e2de449522a5643ec009b4fedd22751e7af6
-windows-amd64-ld-linux-amd64 800175f19d6c2bfe27cf92e7b7c286fb1a459968
-windows-amd64-ld-linux-arm64 af4a20ea92033de3331d6a1add46e8273ecc420d
-windows-amd64-ld-linux-armv6 ae97f91058d79281256e19815a84c792dc15709e
-windows-amd64-ld-linux-armv7 d57ab7ba5e84953069d10ad75ed6d8977df90de1
-windows-amd64-ld-linux-ppc64le e667b511c61b84d83e2956a5aad3d580b66e3c80
-windows-amd64-ld-linux-s390x 92777b3e15b6bdde0c106a86466abc9d0d9cdb94
+linux-386-ld-linux-386 1c6e95b6fa2cd67d5b139d8f59ef42736bca1b29
+linux-386-ld-linux-amd64 3a6a2aeaa926c910348d1272c9100f5a2fc880cc
+linux-386-ld-linux-arm64 54d1a061f1e0ce5b7f0150e0d86d140dbc74e810
+linux-386-ld-linux-armv6 a5ec847effb4dae7ba7ebdba8efac96851f55c52
+linux-386-ld-linux-armv7 4fd68022c815529d31a4104a2eaa4964614fa9b7
+linux-386-ld-linux-ppc64le f3d59fcf8ccd052abee648e89df0035a923b251b
+linux-386-ld-linux-s390x 6347f3b773972302071d56a1cedfcda3616270da
+linux-amd64-ld-linux-386 3e8f208da293ca1726716b9f9176e9eec7bb70d7
+linux-amd64-ld-linux-amd64 080368ec185f7cd46a4d416ec9d9b07a87a0e38e
+linux-amd64-ld-linux-arm64 aa3f0aaa30bde9e3e43ad22abf9cd741571414d8
+linux-amd64-ld-linux-armv6 be9ded3bbb3656351c601d09ed8efb78c345e511
+linux-amd64-ld-linux-armv7 990a6abd228c910f803a68c2d1be140029d955a8
+linux-amd64-ld-linux-ppc64le 0c00ea4fec4284a43499a0823ae2f0d27cc0df7f
+linux-amd64-ld-linux-s390x c69551214da34452bedcdd082e0e5100d30f0123
+linux-arm64-ld-linux-386 4bb1f097624679f77b47755b46bb2420dad53056
+linux-arm64-ld-linux-amd64 c925dee584f3d4fef2c19469c54b4b32b2d6e29c
+linux-arm64-ld-linux-arm64 67e4fe36075015a9f06053db9bda041f628f100c
+linux-arm64-ld-linux-armv6 36f7cc07023b50c368405fcfe5475a7d143f8cbc
+linux-arm64-ld-linux-armv7 8a0eef9ce950480883910914084859f1dfdc2763
+linux-arm64-ld-linux-ppc64le 582cc738880295275c833ce67629d44a6c4735dc
+linux-arm64-ld-linux-s390x 81d000a3111f06a0a3536886dbe1f4b5a65fabf9
+linux-armv6-ld-linux-386 8499efdc3d266e3bc7e97e47fb63372bb9283596
+linux-armv6-ld-linux-amd64 e48a60bdfd05b2fd15313a026d008f572a31f3fa
+linux-armv6-ld-linux-arm64 8aba449dd98656122d20442b6db2119b574af7d8
+linux-armv6-ld-linux-armv6 c9b31c63a5d7af690562d48237020f098fb0d362
+linux-armv6-ld-linux-armv7 618cf8d0b425ca2a73d540ec832b65822211e9da
+linux-armv6-ld-linux-ppc64le 1ded4435d9d2af95fe2600307a7c21463d84d1ab
+linux-armv6-ld-linux-s390x 295a424043251b2ce4c1419e4f50824a17e06f8d
+linux-armv7-ld-linux-386 a545fafc90240152388b9bcfd264db303d2524fb
+linux-armv7-ld-linux-amd64 e03db86d6ddf0aabf16fcd49cf5d96794dc5364b
+linux-armv7-ld-linux-arm64 8b20b6aa8b08619c19c323cdf59c2312aa93ceaf
+linux-armv7-ld-linux-armv6 31e0b269e161245b2811963fa7982d6aac608fbd
+linux-armv7-ld-linux-armv7 133cc2777f712d69b16c3a19ed4f3ca33d992f4b
+linux-armv7-ld-linux-ppc64le 6bc0428090108a37591bef38dec1b8f5105903fc
+linux-armv7-ld-linux-s390x e06e2e4fc0642eb36008b264eaf62f3a1296a9da
+linux-ppc64le-ld-linux-386 b4561d4a74f82e628931bad3daf28c97ce9d7347
+linux-ppc64le-ld-linux-amd64 f3f032245399ff46afc9a2aff051fc6c58b1a62d
+linux-ppc64le-ld-linux-arm64 c6bc1cee1513e8c8109d57a25de2e78f8d643cfe
+linux-ppc64le-ld-linux-armv6 c8bb4beaea974db2b4651cf45853eb72e80e23da
+linux-ppc64le-ld-linux-armv7 693b5617b282bcb1e6fcde2b3abd5b720d3d2f46
+linux-ppc64le-ld-linux-ppc64le b49b5a55cf7d3239bb9ae53350b5635d8a848f29
+linux-ppc64le-ld-linux-s390x f2757e8242fc190c4fcf35c7ece88486b949e2c3
+linux-riscv64-ld-linux-386 030f59c1425f42232e0075a7324640dfb6f835be
+linux-riscv64-ld-linux-amd64 0b5bd6ea0ec242606c4e63458a134dfc6670770c
+linux-riscv64-ld-linux-arm64 03f23014888953b581c3d607bfa35b5c5c66aa88
+linux-riscv64-ld-linux-armv6 2a7491470763390bf89e667869fc16096b9ecc3a
+linux-riscv64-ld-linux-armv7 cad4ee8ee1739cbcf91ace751a3e7e5ffed595c1
+linux-riscv64-ld-linux-ppc64le 2901d8ca953e58961013f12f46e5309c54004d1f
+linux-riscv64-ld-linux-s390x cd875e21040d79d81c6e812232bb9a53e410941d
+linux-s390x-ld-linux-386 e077c4664f58223b5e6f0033aa76f459b7b5b87b
+linux-s390x-ld-linux-amd64 acf4e62ff69b1ed2eba67913a2df3a86285dcc93
+linux-s390x-ld-linux-arm64 3dedd7834e52d3713f6136a62960e90500dc8581
+linux-s390x-ld-linux-armv6 72a780e78f27c50a578f874ed0cb1268430831bf
+linux-s390x-ld-linux-armv7 95d0c9723e6a6f0c6743a928d666783b37ff2ffa
+linux-s390x-ld-linux-ppc64le 2dd0d7d86e1a59f95bc5740d9a9757d1e945c04d
+linux-s390x-ld-linux-s390x 82af2cab690c7bf7d0f50cb1a77e4cb24a4b59ca
+windows-386-ld-linux-386 33acb48796a4819836efae4501ff03d0f735ccdc
+windows-386-ld-linux-amd64 bc69c14e05a95cd36507267169423d19c34be57d
+windows-386-ld-linux-arm64 c7d6edf9c6dc99ac77c1a43afa4c47d63dbbe925
+windows-386-ld-linux-armv6 17f4a54c173f33771864071277ef9406d21e4e34
+windows-386-ld-linux-armv7 90193a36ade422db6a83132a3646df14ccb33c24
+windows-386-ld-linux-ppc64le 9333dfb85995486f42a7d84ad6e5554663bdba99
+windows-386-ld-linux-s390x 22b53c83bdfd7c50d664ad451f5215b7297a65fc
+windows-amd64-ld-linux-386 c33d238d88be7396b2cfcc3fdcb3eb315caf5026
+windows-amd64-ld-linux-amd64 190e25f106c2c94bd4a9eb43c1a1adfa467ab16c
+windows-amd64-ld-linux-arm64 f79e8a5d76f6cb73758ba686032931e0ca79882e
+windows-amd64-ld-linux-armv6 a2bf366e475a05fdd5f76dcb89853c0fa9688732
+windows-amd64-ld-linux-armv7 f80649beea9fda70e571b60b5a8c002e68962dd8
+windows-amd64-ld-linux-ppc64le 85e1ca017bf8336f197612440964483cc48a21f5
+windows-amd64-ld-linux-s390x 5de90ec0906a3a28cc62058b90a89d266590b5d6
 EOT
   )
 


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/issues/3625#issuecomment-1427088968

Use prebuilt ld built from https://github.com/crazy-max/xx/actions/runs/4157262742 and published in https://github.com/tonistiigi/xx/releases/tag/prebuilt%2Fld-2.38-0 while waiting for https://github.com/tonistiigi/xx/pull/68 and https://github.com/tonistiigi/xx/pull/101

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>