### PR TITLE
golang: fix test with pkgconf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
             typ: debian
             allow-failure: true
           -
-            image: debian:bullseye
+            image: debian:bullseye-backports
             typ: debian
             allow-failure: false
           -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,7 @@ jobs:
           -
             image: debian:bookworm
             typ: debian
-            # FIXME: Set to false when https://github.com/tonistiigi/xx/issues/95 fixed
-            allow-failure: true
+            allow-failure: false
           -
             image: debian:sid
             typ: debian

--- a/src/test-go.bats
+++ b/src/test-go.bats
@@ -316,8 +316,9 @@ testHelloCGO() {
   rm -rf /usr/bin/$(xx-info triple)* || true
 
   add llvm
-  add pkg-config || add pkgconf
+  add pkgconf || add pkg-config
   xxadd xx-c-essentials
+  xxadd pkgconf || add pkg-config
   run xx-go env
   assert_success
   assert_output --partial 'CC="'"$(xx-info triple)-clang"'"'


### PR DESCRIPTION
fixes #95 

Since bookworm, `pkgconf` is installed. Before bookworm, crosswrapper scripts were created by a dpkg trigger when `xx-c-essentials` was installed, such as bullseye:

```
$ TARGETARCH=arm64 xx-apt install xx-c-essentials
...
$ ls -al /usr/bin/*pkg-config
lrwxrwxrwx 1 root root    34 Jul 10 08:57 /usr/bin/aarch64-linux-gnu-pkg-config -> /usr/share/pkg-config-crosswrapper
-rwxr-xr-x 2 root root 48000 Apr 21  2020 /usr/bin/aarch64-unknown-linux-gnu-pkg-config
-rwxr-xr-x 2 root root 48000 Apr 21  2020 /usr/bin/pkg-config
lrwxrwxrwx 1 root root    34 Jul 10 08:56 /usr/bin/x86_64-linux-gnu-pkg-config -> /usr/share/pkg-config-crosswrapper
```

Since bookworm this is not the case anymore:

```
$ TARGETARCH=arm64 xx-apt install xx-c-essentials
...
$ ls -al /usr/bin/*pkg-config
lrwxrwxrwx 1 root root 7 Jan 22 11:06 /usr/bin/pkg-config -> pkgconf
lrwxrwxrwx 1 root root 7 Jan 22 11:06 /usr/bin/x86_64-linux-gnu-pkg-config -> pkgconf
```

And therefore test fails.

Installing pkg config cross pkg fixes the issue:

```
$ TARGETARCH=arm64 xx-apt install pkg-config
...
$ ls -al /usr/bin/*pkg-config
lrwxrwxrwx 1 root root 7 Jan 22 11:06 /usr/bin/aarch64-linux-gnu-pkg-config -> pkgconf
lrwxrwxrwx 1 root root 7 Jan 22 11:06 /usr/bin/pkg-config -> pkgconf
lrwxrwxrwx 1 root root 7 Jan 22 11:06 /usr/bin/x86_64-linux-gnu-pkg-config -> pkgconf
```

We are inconsistent but for the sake of the tests it's fine imo.