### PR TITLE
fix bake definition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,8 @@ jobs:
             image: oraclelinux:9
             typ: rhel
             allow-failure: false
+    env:
+      TEST_BASE_TYPE: ${{ matrix.typ }}
     steps:
       -
         name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,5 +188,5 @@ jobs:
           files: |
             ./docker-bake.hcl
             ${{ steps.meta.outputs.bake-file }}
-          targets: base-all
+          targets: xx-all
           push: ${{ github.event_name != 'pull_request' }}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -136,8 +136,8 @@ target "xx" {
     target = "xx"
 }
 
-target "image-all" {
-    inherits = ["image", "_all-platforms"]
+target "xx-all" {
+    inherits = ["xx", "_all-platforms"]
 }
 
 target "sdk-extras" {


### PR DESCRIPTION
Saw this after merging https://github.com/tonistiigi/xx/pull/103: https://github.com/tonistiigi/xx/actions/runs/5521258598/jobs/10069278303#step:7:120

```
  /usr/bin/docker buildx bake --file ./docker-bake.hcl --file /tmp/docker-actions-toolkit-681WDL/docker-metadata-action-bake.json --metadata-file /tmp/docker-build-push-RnQdwz/metadata-file --push base-all --print
  ERROR: failed to find target base-all
  Error: The process '/usr/bin/docker' failed with exit code 1
```

Looks like an oversight.

___

`TEST_BASE_TYPE` was also not set in the workflow.