### PR TITLE
ci: update buildx to latest version

### DIFF
--- a/.github/workflows/bats-assert.yml
+++ b/.github/workflows/bats-assert.yml
@@ -12,6 +12,9 @@ on:
       - '.github/workflows/bats-assert.yml'
       - 'util/bats-assert/**'
 
+env:
+  BUILDX_VERSION: latest
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,6 +27,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
       -
         name: Test
         working-directory: ./util/bats-assert

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ on:
     branches:
       - 'master'
 
+env:
+  BUILDX_VERSION: latest
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -22,6 +25,11 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
       -
         name: Validate
         uses: docker/bake-action@v2
@@ -131,6 +139,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
       -
         name: Test
         if: ${{ matrix.typ != 'rhel' }}
@@ -163,6 +173,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
       -
         name: Docker meta
         id: meta

--- a/.github/workflows/ld.yml
+++ b/.github/workflows/ld.yml
@@ -12,9 +12,11 @@ on:
     tags:
       - 'v*'
     paths:
+      - '.github/workflows/ld.yml'
       - 'src/ld/**'
   pull_request:
     paths:
+      - '.github/workflows/ld.yml'
       - 'src/ld/**'
 
 env:

--- a/.github/workflows/ld.yml
+++ b/.github/workflows/ld.yml
@@ -17,6 +17,9 @@ on:
     paths:
       - 'src/ld/**'
 
+env:
+  BUILDX_VERSION: latest
+
 jobs:
   ld64:
     runs-on: ubuntu-latest
@@ -30,6 +33,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
       -
         name: Build
         uses: docker/bake-action@v2
@@ -46,6 +51,12 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+          driver: docker
       -
         name: Create targets matrix
         id: targets
@@ -75,6 +86,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
       -
         name: Build
         uses: docker/bake-action@v2
@@ -92,6 +105,12 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+          driver: docker
       -
         name: Create targets matrix
         id: targets
@@ -121,6 +140,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
       -
         name: Build
         uses: docker/bake-action@v2

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -12,9 +12,11 @@ on:
     tags:
       - 'v*'
     paths:
+      - '.github/workflows/llvm.yml'
       - 'src/llvm/**'
   pull_request:
     paths:
+      - '.github/workflows/llvm.yml'
       - 'src/llvm/**'
 
 env:

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -17,6 +17,9 @@ on:
     paths:
       - 'src/llvm/**'
 
+env:
+  BUILDX_VERSION: latest
+
 jobs:
   compiler-rt:
     runs-on: ubuntu-latest
@@ -30,6 +33,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
       -
         name: Build
         uses: docker/bake-action@v2
@@ -50,6 +55,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
       -
         name: Build
         uses: docker/bake-action@v2

--- a/.github/workflows/sdk-extras.yml
+++ b/.github/workflows/sdk-extras.yml
@@ -12,9 +12,11 @@ on:
     tags:
       - 'v*'
     paths:
+      - '.github/workflows/sdk-extras.yml'
       - 'src/sdk-extras/**'
   pull_request:
     paths:
+      - '.github/workflows/sdk-extras.yml'
       - 'src/sdk-extras/**'
 
 env:

--- a/.github/workflows/sdk-extras.yml
+++ b/.github/workflows/sdk-extras.yml
@@ -17,6 +17,9 @@ on:
     paths:
       - 'src/sdk-extras/**'
 
+env:
+  BUILDX_VERSION: latest
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -30,6 +33,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
       -
         name: Build
         uses: docker/bake-action@v2


### PR DESCRIPTION
I'm concerned about inconsistency of installed packages on GitHub public runners.

In this run it states Buildx 0.10.4+azure-1 is installed on the runner: https://github.com/tonistiigi/xx/actions/runs/5559878047/jobs/10156423825#step:4:102

![image](https://github.com/tonistiigi/xx/assets/1951866/719cc459-98a4-4915-bbe7-307e0af6dbf6)

But in this one it's Buildx 0.11.1+azure-1: https://github.com/tonistiigi/xx/actions/runs/5559878047/jobs/10156423866#step:4:102

![image](https://github.com/tonistiigi/xx/assets/1951866/b92754a0-314d-4d8a-96d6-a00cef68db5b)

These two runs are part of the same matrix: https://github.com/tonistiigi/xx/actions/runs/5559878047/workflow#L158-L162

Is it a known issue @cpuguy83?