### PR TITLE
test: pin rust version with rustup

### DIFF
--- a/src/test-cargo.bats
+++ b/src/test-cargo.bats
@@ -47,8 +47,17 @@ testHelloCargoRustup() {
 @test "install-rustup" {
   add clang lld curl ca-certificates
   assert_success
-  run sh -c "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --no-modify-path --profile minimal"
+  run sh -c "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.69.0 --no-modify-path --profile=minimal"
   assert_success
+  export "PATH=/root/.cargo/bin:$PATH"
+  run rustup --version 2>/dev/null
+  assert_success
+  assert_output --partial "rustup "
+  run rustc --version
+  assert_success
+  assert_output --partial "rustc "
+  echo "# $(rustup --version 2>/dev/null)" >&3
+  echo "# $(rustc --version)" >&3
 }
 
 @test "amd64-hellocargo-rustup" {


### PR DESCRIPTION
`386-hellocargo-rustup` in alpine 3.13 and 3.14 since rust 0.71.0: https://github.com/tonistiigi/xx/actions/runs/5560116409/jobs/10156856888#step:5:576

![image](https://github.com/tonistiigi/xx/assets/1951866/8eedf748-3758-4af8-8eff-fcab6cc17b52)

Pin rust version to 1.69.0 to fix the test.