### PR TITLE
fix: xx-apk failed to symlink compiler-rt on Alpine 3.18

### DIFF
--- a/src/xx-apk
+++ b/src/xx-apk
@@ -95,7 +95,7 @@ cmd() {
         set -- "$@" g++
         ;;
       "compiler-rt" | "compiler-rt-static")
-        iscompilerrt=1
+        iscompilerrt="$a"
         set -- "$@" "$a"
         ;;
       "rust-stdlib")
@@ -117,12 +117,11 @@ cmd() {
       rm -rf "/${XX_TRIPLE:?}/usr/bin/*"
     fi
     if [ -n "$iscompilerrt" ]; then
-      # shellcheck disable=SC2044
-      for f in $(find /"$(xx-info)"/usr/lib/clang -type f -name "*clang_rt.*"); do
-        ff=${f#/$(xx-info)}
+      for f in $(apk --root "$root" info -qL "$iscompilerrt" | grep 'clang_rt.'); do
+        ff="/${f}"
         if [ ! -f "${ff}" ]; then
           mkdir -p "$(dirname "${ff}")"
-          ln -s "$f" "${ff}"
+          ln -s "/$(xx-info)/${f}" "${ff}"
         fi
       done
     fi


### PR DESCRIPTION
Starting from Alpine 3.18, `compiler-rt` install on `usr/lib/llvm*` instead of `usr/lib/clang`. ([Package contents of 3.17](https://pkgs.alpinelinux.org/contents?file=&path=&name=compiler-rt&branch=v3.17&repo=main&arch=aarch64), [3.18](https://pkgs.alpinelinux.org/contents?file=&path=&name=compiler-rt&branch=v3.18&repo=main&arch=aarch64)) So xx-apk failed to create symlinks with error message below.
```
/opt/app # set -ex
/opt/app # xx-apk add compiler-rt
+ xx-apk add compiler-rt
+ apk  --root /aarch64-alpine-linux-musl add compiler-rt
OK: 55 MiB in 7 packages
find: /aarch64-alpine-linux-musl/usr/lib/clang: No such file or directory
```

Here is sample output of `apk info -qL compiler-rt`
```
/ # apk info -qL compiler-rt
usr/lib/clang/15.0.7/bin/hwasan_symbolize
usr/lib/clang/15.0.7/include/fuzzer/FuzzedDataProvider.h
usr/lib/clang/15.0.7/include/orc/c_api.h
usr/lib/clang/15.0.7/include/profile/InstrProfData.inc
usr/lib/clang/15.0.7/include/sanitizer/allocator_interface.h
usr/lib/clang/15.0.7/include/sanitizer/asan_interface.h
usr/lib/clang/15.0.7/include/sanitizer/common_interface_defs.h
usr/lib/clang/15.0.7/include/sanitizer/coverage_interface.h
usr/lib/clang/15.0.7/include/sanitizer/dfsan_interface.h
usr/lib/clang/15.0.7/include/sanitizer/hwasan_interface.h
usr/lib/clang/15.0.7/include/sanitizer/linux_syscall_hooks.h
usr/lib/clang/15.0.7/include/sanitizer/lsan_interface.h
usr/lib/clang/15.0.7/include/sanitizer/msan_interface.h
usr/lib/clang/15.0.7/include/sanitizer/netbsd_syscall_hooks.h
usr/lib/clang/15.0.7/include/sanitizer/scudo_interface.h
usr/lib/clang/15.0.7/include/sanitizer/tsan_interface.h
usr/lib/clang/15.0.7/include/sanitizer/tsan_interface_atomic.h
...
```