### PR TITLE
debian/ubuntu: fix apt sources list location

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ ARG TARGETPLATFORM
 RUN xx-apt-get install -y libc6-dev zlib1g-dev
 ```
 
+> [!NOTE]
+> `xx-apt --print-source-file` can be used to print the path of the main [Apt sources configuration file](https://manpages.debian.org/bookworm/apt/sources.list.5.en.html)
+
 Installing two meta-libraries, `xx-c-essentials`, `xx-cxx-essentials` is also allowed that expand the minimum necessary packages for either base image.
 
 ## `xx-verify` - Verifying compilation results

--- a/README.md
+++ b/README.md
@@ -146,8 +146,7 @@ RUN xx-clang --static -o /out/myapp app.c && \
     xx-verify --static /out/myapp
 ```
 
-> **Note**
-> 
+> [!NOTE]
 > `XX_VERIFY_STATIC=1` environment variable can be defined to make `xx-verify`
 > always verify that the compiler produced a static binary.
 
@@ -372,8 +371,7 @@ RUN cargo build --target=$(xx-cargo --print-target-triple) --release --target-di
     xx-verify ./build/$(xx-cargo --print-target-triple)/release/hello_cargo
 ```
 
-> **Note**
->
+> [!NOTE]
 > `xx-cargo --print-target-triple` does not always have the same value as
 > `xx-clang --print-target-triple`. This is because prebuilt Rust and C
 > libraries sometimes use a different value.
@@ -400,8 +398,7 @@ RUN --mount=type=cache,target=/root/.cargo/git/db \
     xx-verify ./build/$(xx-cargo --print-target-triple)/release/hello_cargo
 ```
 
-> **Note**
->
+> [!NOTE]
 > By calling `cargo fetch` before `ARG TARGETPLATFORM` your packages are
 > fetched only once for the whole build while the building happens separately
 > for each target architecture.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -32,7 +32,6 @@ target "test-alpine" {
 target "test-debian" {
     inherits = ["test-src"]
     args = {
-        APT_MIRROR = "cdn-fastly.deb.debian.org"
         TEST_BASE_TYPE = "debian"
         TEST_BASE_IMAGE = "debian:bookworm"
     }

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -25,15 +25,11 @@ RUN --mount=type=cache,target=/pkg-cache \
 WORKDIR /work
 
 FROM ${TEST_BASE_IMAGE} AS test-base-debian
-ARG APT_MIRROR=deb.debian.org
 RUN --mount=type=cache,target=/pkg-cache \
     rm -rf /var/cache/apt/archives && \
     ln -s /pkg-cache /var/cache/apt/archives && \
     rm /etc/apt/apt.conf.d/docker-clean && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "1";' > /etc/apt/apt.conf.d/keep-downloads && \
-    touch /etc/apt/sources.list && \
-    sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list && \
-    sed -ri "s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g" /etc/apt/sources.list && \
     apt update && apt install --no-install-recommends -y bats vim
 WORKDIR /work
 

--- a/src/test-apt.bats
+++ b/src/test-apt.bats
@@ -219,3 +219,12 @@ load 'assert'
   run apt show wget-notexist
   assert_failure
 }
+
+@test "print-source-file" {
+  run xx-apt --print-source-file
+  assert_success
+  assert_output --partial "/etc/apt/sources.list"
+
+  run test -e "$(xx-apt --print-source-file)"
+  assert_success
+}

--- a/src/xx-apt
+++ b/src/xx-apt
@@ -38,6 +38,20 @@ exitnolinux() {
   fi
 }
 
+n=$#
+for a in "$@"; do
+  if [ $# = $n ]; then set --; fi
+  case "$a" in
+    "--print-source-file")
+      aptsourcesfile
+      exit 0
+      ;;
+    *)
+      set -- "$@" "$a"
+      ;;
+  esac
+done
+
 # these are not supported yet
 case "${TARGETARCH}" in
   mips*)

--- a/src/xx-apt
+++ b/src/xx-apt
@@ -21,6 +21,16 @@ checkpkg() {
   apt show "$@"
 }
 
+aptsourcesfile() {
+  if [ -f /etc/apt/sources.list.d/debian.sources ]; then
+    echo /etc/apt/sources.list.d/debian.sources
+  elif [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+    echo /etc/apt/sources.list.d/ubuntu.sources
+  else
+    echo /etc/apt/sources.list
+  fi
+}
+
 exitnolinux() {
   if [ "${TARGETOS}" != "linux" ]; then
     echo >&2 "skipping packages installation on ${XX_OS}"
@@ -37,7 +47,7 @@ case "${TARGETARCH}" in
   riscv*)
     case "${XX_VENDOR}" in
       debian)
-        if ! grep "sid main" /etc/apt/sources.list >/dev/null; then
+        if ! grep "sid main" "$(aptsourcesfile)" >/dev/null; then
           echo >&2 "skipping packages installation on ${XX_ARCH}. riscv64 currently only supported on sid"
           exit 0
         fi
@@ -64,7 +74,7 @@ fi
 fixubuntusources() {
   # fix all current sources to native arch
   nativearch="$(TARGETPLATFORM="" TARGETPAIR="" TARGETARCH="" TARGETOS="" xx-info arch)"
-  sed -E "/arch=/! s/^(# )?(deb|deb-src) /\1\2 [arch=$nativearch] /" -i /etc/apt/sources.list
+  sed -E "/arch=/! s/^(# )?(deb|deb-src) /\1\2 [arch=$nativearch] /" -i "$(aptsourcesfile)"
 
   if ! xx-info is-cross; then return; fi
 


### PR DESCRIPTION
related to https://github.com/moby/moby/pull/44735#issuecomment-1866355689

needs #133 

Since Ubuntu Noble 24.04 and Debian Bookworm, `/etc/apt/sources.list` has moved to `/etc/apt/sources.list.d/ubuntu.sources` and `/etc/apt/sources.list.d/debian.sources` respectively.

They also use the new deb822 format: https://repolib.readthedocs.io/en/latest/deb822-format.html

```
docker run --rm -it debian:12 cat /etc/apt/sources.list.d/debian.sources
Types: deb
# http://snapshot.debian.org/archive/debian/20231218T000000Z
URIs: http://deb.debian.org/debian
Suites: bookworm bookworm-updates
Components: main
Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg

Types: deb
# http://snapshot.debian.org/archive/debian-security/20231218T000000Z
URIs: http://deb.debian.org/debian-security
Suites: bookworm-security
Components: main
Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
```