### PR TITLE
hack: fix dev-shell script

### DIFF
--- a/hack/dev-shell
+++ b/hack/dev-shell
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-docker buildx build --load -t tonistiigi/xx:dev --build-arg TEST_BASE_TYPE --build-arg TEST_BASE_IMAGE --build-arg TEST_WITH_DARWIN --target=dev ./base
+docker buildx bake dev
 
 if ! docker volume inspect xx-pkg-cache >/dev/null 2>&1; then
   docker volume create xx-pkg-cache >/dev/null 2>&1

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -101,8 +101,8 @@ FROM scratch AS sdk-extras
 
 # dev can be used for debugging during development
 FROM test-base AS dev
-COPY --from=sdk-extras / /
-COPY --from=xx / /
+COPY --link --from=sdk-extras / /
+COPY --link --from=xx / /
 COPY fixtures fixtures
 COPY *.bats test_helper.bash ./
 


### PR DESCRIPTION
Fixes the dev-shell support that looks broken after the source migration to `/src`.

Supports:
```
 ./hack/dev-shell
 TEST_BASE_TYPE=debian ./hack/dev-shell
 TEST_BASE_TYPE=debian TEST_BASE_IMAGE=debian:sid ./hack/dev-shell
 DEV_SDK_PLATFORM=darwin/arm64 ./hack/dev-shell
```