### PR TITLE
dockerfile: switch to vault repo for centos 7

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -37,19 +37,23 @@ WORKDIR /work
 FROM ${TEST_BASE_IMAGE} AS test-base-rhel
 RUN <<EOT
 set -ex
+. /etc/os-release
+if [[ "$ID" = "centos" ]] && [[ "$VERSION_ID" = "7" ]]; then
+  # CentOS 7 is EOL since June 30, 2024, use vault.centos.org
+  sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+  sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
 if ! yum install -y epel-release; then
-  if . /etc/os-release 2>/dev/null; then
-    case "$ID" in
-      fedora) ;;
-      rocky)
-        dnf install -y epel-release
-        ;;
-      *)
-        yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-${VERSION:0:1}.noarch.rpm
-        yum update -y
-        ;;
-    esac
-  fi
+  case "$ID" in
+    fedora) ;;
+    rocky)
+      dnf install -y epel-release
+      ;;
+    *)
+      yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-${VERSION:0:1}.noarch.rpm
+      yum update -y
+      ;;
+  esac
 fi
 if command -v dnf >/dev/null 2>/dev/null; then
   dnf install -y bats vim


### PR DESCRIPTION
relates to https://github.com/tonistiigi/xx/actions/runs/10112723728/job/27985481000#step:6:423

```
#21 1.333 + yum update -y
#21 1.426 Loaded plugins: fastestmirror, ovl
#21 1.469 Loading mirror speeds from cached hostfile
#21 1.530 Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
#21 1.530 14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error"
```

CentOS 7 has reached EOL on June 30: https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7. Switch to vault repo.