### PR TITLE
ensure /var/lock dir exists

### DIFF
--- a/src/xx-apk
+++ b/src/xx-apk
@@ -3,6 +3,11 @@
 set -e
 
 if [ -z "$XX_APK_NOLOCK" ]; then
+  if [ -L /var/lock ] && [ ! -e "$(readlink -f /var/lock)" ]; then
+    mkdir -p "$(readlink -f /var/lock)"
+  elif [ ! -d /var/lock ]; then
+    mkdir -p /var/lock
+  fi
   lock="/var/lock/xx-apk"
   exec 9>$lock
   flock -x 9

--- a/src/xx-apt
+++ b/src/xx-apt
@@ -3,6 +3,11 @@
 set -e
 
 if [ -z "$XX_APT_NOLOCK" ]; then
+  if [ -L /var/lock ] && [ ! -e "$(readlink -f /var/lock)" ]; then
+    mkdir -p "$(readlink -f /var/lock)"
+  elif [ ! -d /var/lock ]; then
+    mkdir -p /var/lock
+  fi
   lock="/var/lock/xx-apt"
   exec 9>$lock
   flock -x 9

--- a/src/xx-cargo
+++ b/src/xx-cargo
@@ -10,6 +10,11 @@ execSilent() {
 }
 
 if [ -z "$XX_CARGO_NOLOCK" ]; then
+  if [ -L /var/lock ] && [ ! -e "$(readlink -f /var/lock)" ]; then
+    mkdir -p "$(readlink -f /var/lock)"
+  elif [ ! -d /var/lock ]; then
+    mkdir -p /var/lock
+  fi
   lock="/var/lock/xx-cargo"
   exec 9>$lock
   flock -x 9

--- a/src/xx-cc
+++ b/src/xx-cc
@@ -301,6 +301,11 @@ fi
 
 setup() {
   if [ -z "$XX_CC_NOLOCK" ]; then
+    if [ -L /var/lock ] && [ ! -e "$(readlink -f /var/lock)" ]; then
+      mkdir -p "$(readlink -f /var/lock)"
+    elif [ ! -d /var/lock ]; then
+      mkdir -p /var/lock
+    fi
     lock="/var/lock/xx-cc"
     exec 9>$lock
     flock -x 9

--- a/src/xx-verify
+++ b/src/xx-verify
@@ -3,6 +3,11 @@
 set -e
 
 if [ -z "$XX_VERIFY_NOLOCK" ]; then
+  if [ -L /var/lock ] && [ ! -e "$(readlink -f /var/lock)" ]; then
+    mkdir -p "$(readlink -f /var/lock)"
+  elif [ ! -d /var/lock ]; then
+    mkdir -p /var/lock
+  fi
   lock="/var/lock/xx-verify"
   exec 9>$lock
   flock -x 9


### PR DESCRIPTION
relates to https://github.com/tonistiigi/xx/actions/runs/10355410498/job/28662989273#step:5:784

```
  > [test-apk test-apk 2/2] RUN --mount=type=cache,target=/pkg-cache,sharing=locked [ ! -f /etc/alpine-release ] || ./test-apk.bats:
0.515 not ok 5 skip-nolinux
0.517 # (from function `assert_success' in file bats-assert/src/assert.bash, line 114,
0.517 #  in test file test-apk.bats, line 54)
0.519 #   `assert_success' failed
0.520 #
0.520 # -- command failed --
0.520 # status : 1
0.520 # output : /usr/bin/xx-apk: line 7: can't create /var/lock/xx-apk: nonexistent directory
0.520 # --
0.520 #
```

Alpine edge has `/var/lock` as symlink to `/run/lock` but this dir doesn't exist:

```
$ docker run --rm -it alpine:edge sh -xc "ls -al /var/ && ls -al /run"
+ ls -al /var/
total 44
drwxr-xr-x   11 root     root          4096 Aug  7 16:24 .
drwxr-xr-x    1 root     root          4096 Aug 20 16:12 ..
drwxr-xr-x    4 root     root          4096 Aug  7 16:24 cache
dr-xr-xr-x    2 root     root          4096 Aug  7 16:24 empty
drwxr-xr-x    3 root     root          4096 Aug  7 16:24 lib
drwxr-xr-x    2 root     root          4096 Aug  7 16:24 local
lrwxrwxrwx    1 root     root             9 Aug  7 16:24 lock -> /run/lock
drwxr-xr-x    2 root     root          4096 Aug  7 16:24 log
drwxr-xr-x    2 root     root          4096 Aug  7 16:24 mail
drwxr-xr-x    2 root     root          4096 Aug  7 16:24 opt
lrwxrwxrwx    1 root     root             4 Aug  7 16:24 run -> /run
drwxr-xr-x    3 root     root          4096 Aug  7 16:24 spool
drwxrwxrwt    2 root     root          4096 Aug  7 16:24 tmp
+ ls -al /run
total 8
drwxr-xr-x    2 root     root          4096 Aug  7 16:24 .
drwxr-xr-x    1 root     root          4096 Aug 20 16:12 ..
```

And Alpine latest `/var/lock` is a dir:

```
docker run --rm -it alpine:latest sh -xc "ls -al /var/ && ls -al /run"
+ ls -al /var/
total 48
drwxr-xr-x   12 root     root          4096 Jun 18 14:16 .
drwxr-xr-x    1 root     root          4096 Aug 20 16:13 ..
drwxr-xr-x    4 root     root          4096 Jun 18 14:16 cache
dr-xr-xr-x    2 root     root          4096 Jun 18 14:16 empty
drwxr-xr-x    3 root     root          4096 Jun 18 14:16 lib
drwxr-xr-x    2 root     root          4096 Jun 18 14:16 local
drwxr-xr-x    3 root     root          4096 Jun 18 14:16 lock
drwxr-xr-x    2 root     root          4096 Jun 18 14:16 log
drwxr-xr-x    2 root     root          4096 Jun 18 14:16 mail
drwxr-xr-x    2 root     root          4096 Jun 18 14:16 opt
lrwxrwxrwx    1 root     root             4 Jun 18 14:16 run -> /run
drwxr-xr-x    3 root     root          4096 Jun 18 14:16 spool
drwxrwxrwt    2 root     root          4096 Jun 18 14:16 tmp
+ ls -al /run
total 8
drwxr-xr-x    2 root     root          4096 Jun 18 14:16 .
drwxr-xr-x    1 root     root          4096 Aug 20 16:13 ..
```

So makes sure lock folder exists.