### PR TITLE
test-go: print version

### DIFF
--- a/src/test-go.bats
+++ b/src/test-go.bats
@@ -62,6 +62,13 @@ testEnv() {
   esac
 }
 
+@test "version" {
+  run go version 2>/dev/null
+  assert_success
+  assert_output --partial "go version "
+  echo "# $(go version 2>/dev/null)" >&3
+}
+
 @test "nogo" {
   if command -v apk >/dev/null 2>/dev/null; then
     del go


### PR DESCRIPTION
* needs #180
* relates to #177 

https://github.com/tonistiigi/xx/actions/runs/12236180951/job/34129079148#step:5:1002

```
#83 77.99 1..49
#83 89.73 # go version go1.18.1 linux/amd64
#83 89.73 ok 1 version
```