### PR TITLE
test: fix bats setup/teardown

### DIFF
--- a/src/test-go.bats
+++ b/src/test-go.bats
@@ -12,11 +12,11 @@ ensureGo() {
   add clang lld
 }
 
-setup_file() {
+setup() {
   ensureGo
 }
 
-teardown_file() {
+teardown() {
   for p in linux/amd64 linux/arm64 linux/ppc64le linux/s390x linux/386 linux/arm/v7 linux/arm/v6 linux/riscv64; do
     TARGETPLATFORM=$p xxdel xx-c-essentials
     root=/$(TARGETPLATFORM=$p xx-info triple)


### PR DESCRIPTION
follow-up https://github.com/tonistiigi/xx/pull/178#issuecomment-2528048365

`setup_file` and `teardown_file` are available since bats 1.2.1 but Ubuntu 20.04 currently ships Bats 1.2.0-dev.

We can use `setup` and `teardown` which would behave the same.