### PR TITLE
ci: ubuntu 23.04 eol

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,10 +88,6 @@ jobs:
             typ: debian
             allow-failure: false
           -
-            image: ubuntu:23.04
-            typ: debian
-            allow-failure: false
-          -
             image: ubuntu:24.04
             typ: debian
             allow-failure: false


### PR DESCRIPTION
relates to https://github.com/tonistiigi/xx/actions/runs/12239168823/job/34138978886#step:5:634

```
#49 0.065 
#49 0.065 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
#49 0.065 
#49 0.139 Ign:1 http://security.ubuntu.com/ubuntu lunar-security InRelease
#49 0.166 Err:2 http://security.ubuntu.com/ubuntu lunar-security Release
#49 0.166   404  Not Found [IP: 91.189.91.82 80]
#49 0.294 Ign:3 http://archive.ubuntu.com/ubuntu lunar InRelease
#49 0.385 Ign:4 http://archive.ubuntu.com/ubuntu lunar-updates InRelease
#49 0.476 Ign:5 http://archive.ubuntu.com/ubuntu lunar-backports InRelease
#49 0.568 Err:6 http://archive.ubuntu.com/ubuntu lunar Release
#49 0.568   404  Not Found [IP: 185.125.190.82 80]
#49 0.659 Err:7 http://archive.ubuntu.com/ubuntu lunar-updates Release
#49 0.659   404  Not Found [IP: 185.125.190.82 80]
#49 0.750 Err:8 http://archive.ubuntu.com/ubuntu lunar-backports Release
#49 0.750   404  Not Found [IP: 185.125.190.82 80]
#49 0.752 Reading package lists...
#49 0.765 E: The repository 'http://security.ubuntu.com/ubuntu lunar-security Release' does not have a Release file.
#49 0.765 E: The repository 'http://archive.ubuntu.com/ubuntu lunar Release' does not have a Release file.
#49 0.765 E: The repository 'http://archive.ubuntu.com/ubuntu lunar-updates Release' does not have a Release file.
#49 0.765 E: The repository 'http://archive.ubuntu.com/ubuntu lunar-backports Release' does not have a Release file.
```