### PR TITLE
test: skip mips go build on ubuntu 22.04

### DIFF
--- a/src/test-go.bats
+++ b/src/test-go.bats
@@ -307,11 +307,17 @@ testHelloGO() {
 }
 
 @test "mipsle-hellogo" {
+  if ! supportMipsBuildGo; then
+    skip "MIPS build not supported"
+  fi
   export TARGETARCH=mipsle
   testHelloGO
 }
 
 @test "mipsle-softfloat-hellogo" {
+  if ! supportMipsBuildGo; then
+    skip "MIPS build not supported"
+  fi
   export TARGETARCH=mipsle
   export TARGETVARIANT=softfloat
   testHelloGO
@@ -319,11 +325,17 @@ testHelloGO() {
 }
 
 @test "mips64le-hellogo" {
+  if ! supportMipsBuildGo; then
+    skip "MIPS build not supported"
+  fi
   export TARGETARCH=mips64le
   testHelloGO
 }
 
 @test "mips64le-softfloat-hellogo" {
+  if ! supportMipsBuildGo; then
+    skip "MIPS build not supported"
+  fi
   export TARGETARCH=mips64le
   export TARGETVARIANT=softfloat
   testHelloGO

--- a/src/test_helper.bash
+++ b/src/test_helper.bash
@@ -95,6 +95,12 @@ supportAmd64VariantGo() {
   versionGTE "$(go version | awk '{print $3}' | sed 's/^go//')" "1.18"
 }
 
+# Supported since Go 1.13: https://go.dev/wiki/GoMips
+# But fails on Ubuntu 22.04 with Go 1.18.1: https://github.com/tonistiigi/xx/issues/177
+supportMipsBuildGo() {
+  ! grep -q 'ID=ubuntu' /etc/os-release && ! grep -q 'VERSION_ID="22.04"' /etc/os-release && versionGTE "$(go version | awk '{print $3}' | sed 's/^go//')" "1.13"
+}
+
 supportRC() {
   command -v llvm-rc >/dev/null 2>&1
 }


### PR DESCRIPTION
* fixes #177