### PR TITLE
ci: allow failure for bullseye-backports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           -
             image: debian:bullseye-backports
             typ: debian
-            allow-failure: false
+            allow-failure: true
           -
             image: debian:bookworm
             typ: debian


### PR DESCRIPTION
relates to: https://github.com/tonistiigi/xx/actions/runs/12241031255/job/34145224508#step:5:962

```
#88 120.2 not ok 6 ppc64le-hellocargo-rustup
#88 120.2 # (from function `assert_success' in file bats-assert/src/assert.bash, line 114,
#88 120.2 #  from function `testHelloCargo' in file test-cargo.bats, line 30,
#88 120.2 #  from function `testHelloCargoRustup' in file test-cargo.bats, line 44,
#88 120.2 #  in test file test-cargo.bats, line 83)
#88 120.3 #   `testHelloCargoRustup' failed
#88 120.3 #
#88 120.3 # -- command failed --
#88 120.3 # status : 100
#88 120.3 # output (19 lines):
#88 120.3 #   + apt  install -y --no-install-recommends libc6-dev:ppc64el libgcc-10-dev:ppc64el
#88 120.3 #
#88 120.3 #   WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
#88 120.3 #
#88 120.3 #   Reading package lists...
#88 120.3 #   Building dependency tree...
#88 120.3 #   Reading state information...
#88 120.3 #   Some packages could not be installed. This may mean that you have
#88 120.3 #   requested an impossible situation or if you are using the unstable
#88 120.3 #   distribution that some required packages have not yet been created
#88 120.3 #   or been moved out of Incoming.
#88 120.3 #   The following information may help to resolve the situation:
#88 120.3 #
#88 120.3 #   The following packages have unmet dependencies:
#88 120.3 #    libc6-dev:ppc64el : Depends: linux-libc-dev:ppc64el but it is not going to be installed
#88 120.3 #    libgssapi-krb5-2:ppc64el : Depends: libcom-err2:ppc64el (>= 1.43.9) but it is not going to be installed
#88 120.3 #    libkrb5-3:ppc64el : Depends: libcom-err2:ppc64el (>= 1.43.9) but it is not going to be installed
#88 120.3 #                        Depends: libssl1.1:ppc64el (>= 1.1.0) but it is not going to be installed
#88 120.3 #   E: Unable to correct problems, you have held broken packages.
#88 120.3 # --
```