### PR TITLE
xx-apk: fix problem with writing lock in latest alpine

### DIFF
--- a/src/xx-apk
+++ b/src/xx-apk
@@ -3,11 +3,14 @@
 set -e
 
 if [ -z "$XX_APK_NOLOCK" ]; then
+  # readlink -f in ash can not resolve symlinks from deep workdir
+  cd /
   if [ -L /var/lock ] && [ ! -e "$(readlink -f /var/lock)" ]; then
     mkdir -p "$(readlink -f /var/lock)"
   elif [ ! -d /var/lock ]; then
     mkdir -p /var/lock
   fi
+  cd -
   lock="/var/lock/xx-apk"
   exec 9>$lock
   flock -x 9


### PR DESCRIPTION
`xx-apk` can return `0.069 mkdir: can't create directory '': No such file or directory` in latest alpine 3.21 https://github.com/tonistiigi/xx/blob/b0cde9e3c6120fc0b4b118bdd463ced0feb04070/src/xx-apk#L7 because `readlink -f` does not return a valid path. This seems to depend on the working directory. I don't see such behavior in `coreutils` and `man readlink` also does not suggest this as a valid behavior afaics.

As a workaround, temporarily switch the working directory to root before calling `readlink`.