### PR TITLE
ci: split tests in a reusable workflow

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -1,0 +1,98 @@
+# reusable workflow
+name: .test
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        required: true
+        type: string
+      base:
+        required: true
+        type: string
+      allow-failure:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.generate.outputs.targets }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: List targets
+        id: generate
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const base = `${{ inputs.base }}`;
+            
+            await core.group(`Validating definition`, async () => {
+              const res = await exec.getExecOutput('docker', ['buildx', 'bake', 'test', '--print'], {
+                ignoreReturnCode: true,
+                silent: true
+              });
+              if (res.stderr.length > 0 && res.exitCode != 0) {
+                throw new Error(res.stderr);
+              }
+              def = JSON.parse(res.stdout.trim());
+              core.info(JSON.stringify(def, null, 2));
+            });
+            
+            const targets = [];
+            for (const target of Object.keys(def.target)) {
+              switch (base) {
+                case 'alpine':
+                  if (target !== 'test-apt') {
+                    targets.push(target);
+                  }
+                  break;
+                case 'debian':
+                  if (target !== 'test-apk') {
+                    targets.push(target);
+                  }
+                  break;
+                case 'rhel':
+                  if (target === 'test-info') {
+                    targets.push(target);
+                  }
+                  break;
+                default:
+                  targets.push(target);
+              }
+            }
+  
+            await core.group(`Set output`, async () => {
+              core.info(`targets: ${JSON.stringify(targets)}`);
+              core.setOutput('targets', JSON.stringify(targets));
+            });
+
+  test:
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ inputs.allow-failure }}
+    needs:
+      - prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.prepare.outputs.targets) }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Test
+        uses: docker/bake-action@v5
+        with:
+          provenance: false
+          targets: ${{ matrix.target }}
+          set: |
+            test-${{ inputs.base }}.args.TEST_BASE_IMAGE=${{ inputs.image }}
+        env:
+          TEST_BASE_TYPE: ${{ inputs.base }}
+          DOCKER_BUILD_SUMMARY: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,136 +29,112 @@ jobs:
           targets: validate
 
   test:
-    runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allow-failure }}
+    uses: ./.github/workflows/.test.yml
+    secrets: inherit
     strategy:
       fail-fast: false
       matrix:
         include:
           -
             image: alpine:3.17
-            typ: alpine
+            base: alpine
             allow-failure: false
           -
             image: alpine:3.18
-            typ: alpine
+            base: alpine
             allow-failure: false
           -
             image: alpine:3.19
-            typ: alpine
+            base: alpine
             allow-failure: false
           -
             image: alpine:3.20
-            typ: alpine
+            base: alpine
             allow-failure: false
           -
             image: alpine:3.21
-            typ: alpine
+            base: alpine
             allow-failure: false
           -
             image: alpine:edge
-            typ: alpine
+            base: alpine
             allow-failure: true
           -
             image: debian:bullseye-backports
-            typ: debian
+            base: debian
             allow-failure: true
           -
             image: debian:bookworm
-            typ: debian
+            base: debian
             allow-failure: false
           -
             image: debian:bookworm-backports
-            typ: debian
+            base: debian
             allow-failure: false
           -
             image: debian:trixie
-            typ: debian
+            base: debian
             allow-failure: false
           -
             image: debian:sid
-            typ: debian
+            base: debian
             allow-failure: true
           -
             image: ubuntu:20.04
-            typ: debian
+            base: debian
             allow-failure: false
           -
             image: ubuntu:22.04
-            typ: debian
+            base: debian
             allow-failure: false
           -
             image: ubuntu:24.04
-            typ: debian
+            base: debian
             allow-failure: false
           -
             image: redhat/ubi8
-            typ: rhel
+            base: rhel
             allow-failure: false
           -
             image: fedora:38
-            typ: rhel
+            base: rhel
             allow-failure: false
           -
             image: fedora:39
-            typ: rhel
+            base: rhel
             allow-failure: false
           -
             image: fedora:40
-            typ: rhel
+            base: rhel
             allow-failure: false
           -
             image: fedora:41
-            typ: rhel
+            base: rhel
             allow-failure: false
           -
             image: centos:7
-            typ: rhel
+            base: rhel
             allow-failure: false
           -
             image: rockylinux/rockylinux:8
-            typ: rhel
+            base: rhel
             allow-failure: false
           -
             image: rockylinux/rockylinux:9
-            typ: rhel
+            base: rhel
             allow-failure: false
           -
             image: oraclelinux:8
-            typ: rhel
+            base: rhel
             allow-failure: false
           -
             image: oraclelinux:9
-            typ: rhel
+            base: rhel
             allow-failure: false
-    env:
-      TEST_BASE_TYPE: ${{ matrix.typ }}
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Test
-        if: ${{ matrix.typ != 'rhel' }}
-        uses: docker/bake-action@v5
-        with:
-          targets: test
-          set: |
-            test-${{ matrix.typ }}.args.TEST_BASE_IMAGE=${{ matrix.image }}
-      -
-        name: Test (info)
-        if: ${{ matrix.typ == 'rhel' }}
-        uses: docker/bake-action@v5
-        with:
-          targets: test-info
-          set: |
-            test-${{ matrix.typ }}.args.TEST_BASE_IMAGE=${{ matrix.image }}
+    with:
+      image: ${{ matrix.image }}
+      base: ${{ matrix.base }}
+      allow-failure: ${{ matrix.allow-failure }}
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Will make it easier to find out what fails:

![image](https://github.com/user-attachments/assets/a70df3cc-0f85-434b-95e9-f54b6a3533c3)

And also improve build time:

Before:

![image](https://github.com/user-attachments/assets/d8e31f7b-a1af-4a80-87de-e3ceefe870cd)

Now:

![image](https://github.com/user-attachments/assets/82825185-5fe0-4216-88be-e0743bda8118)
