### PR TITLE
xx-verify: skip non-binary

### DIFF
--- a/src/test-verify.bats
+++ b/src/test-verify.bats
@@ -372,6 +372,53 @@ load 'assert'
   export TARGETPLATFORM=linux/amd64
   run xx-verify /idontexist
   assert_failure
+}
+
+@test "not-binary" {
+  export XX_VERIFY_FILE_CMD_OUTPUT="POSIX shell script, ASCII text executable"
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_success
+
+  export XX_VERIFY_FILE_CMD_OUTPUT="Bourne-Again shell script, ASCII text executable"
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_success
+
+  export XX_VERIFY_FILE_CMD_OUTPUT="Python script, ASCII text executable"
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_success
+
+  export XX_VERIFY_FILE_CMD_OUTPUT="C source, ASCII text"
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_success
+
+  export XX_VERIFY_FILE_CMD_OUTPUT="UTF-8 Unicode text"
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_success
+
+  export XX_VERIFY_FILE_CMD_OUTPUT="XML document text"
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_success
+
+  export XX_VERIFY_FILE_CMD_OUTPUT="Markdown document text"
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_success
+
+  export XX_VERIFY_FILE_CMD_OUTPUT="YAML document text"
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_success
+
+  export XX_VERIFY_FILE_CMD_OUTPUT="JSON data"
+  export TARGETPLATFORM=linux/amd64
+  run xx-verify /idontexist
+  assert_success
 
   unset XX_VERIFY_FILE_CMD_OUTPUT
   unset TARGETPLATFORM

--- a/src/xx-verify
+++ b/src/xx-verify
@@ -122,6 +122,13 @@ for f in "$@"; do
       ;;
   esac
 
+  case "$out" in
+    *"ASCII text"* | *"Unicode text"* | *"document text"* | *"JSON data"*)
+      echo "skipping verification of non-binary file ${f}: $out"
+      exit 0
+      ;;
+  esac
+
   if [ -z "$expOS" ]; then
     echo >&2 "unsupported target os ${TARGETOS}"
     exit 1


### PR DESCRIPTION
follow-up https://github.com/tonistiigi/xx/pull/189#issuecomment-2535868598

https://github.com/tonistiigi/xx/actions/runs/12275235320/job/34249881455#step:5:30760

```
715.3 make[2]: Leaving directory '/work/binutils-2.42/libiberty'
715.3 make[1]: Nothing to be done for 'install-target'.
715.3 make[1]: Leaving directory '/work/binutils-2.42'
715.3 + cd ..
715.3 + rm -rf binutils-2.42
xx-verify /out/bin/powerpc64le-alpine-linux-musl-c++filt
717.4 + xx-verify /out/bin/powerpc64le-alpine-linux-musl-dwp
717.5 + xx-verify /out/bin/powerpc64le-alpine-linux-musl-elfedit
717.5 + xx-verify /out/bin/powerpc64le-alpine-linux-musl-embedspu
717.5 file /out/bin/powerpc64le-alpine-linux-musl-embedspu does not match expected target OS linux: POSIX shell script, ASCII text executable
```

I think we should skip and not fail if file is not a binary.