### PR TITLE
xx-apk: fix mkdir

### DIFF
--- a/src/xx-apk
+++ b/src/xx-apk
@@ -59,8 +59,8 @@ setup() {
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/main" >"$apk_dir/repositories"
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/community" >>"$apk_dir/repositories"
   fi
-  mkdir "$apk_dir/keys"
-  mkdir "$apk_dir/protected_paths.d"
+  mkdir -p "$apk_dir/keys"
+  mkdir -p "$apk_dir/protected_paths.d"
   echo "$XX_PKG_ARCH" >"$apk_dir/arch"
   apk add --no-cache --initdb -p "/${XX_TRIPLE}" --allow-untrusted alpine-keys
 


### PR DESCRIPTION
relates to https://github.com/tonistiigi/xx/actions/runs/12260586308/job/34205579093#step:5:879

```
> [test-clang test-clang 2/2] RUN --mount=type=cache,target=/pkg-cache,sharing=locked ./test-clang.bats:
43.15 #  in test file test-clang.bats, line 313)
43.15 #   `testHelloCPPLLD' failed
43.15 # rm: can't remove '/etc/llvm/xx-default.cfg': No such file or directory
43.15 # rm: can't remove '/usr/bin/*-apple-*-clang': No such file or directory
43.16 # rm: can't remove '/usr/bin/*-apple-*-clang++': No such file or directory
43.16 # mkdir: can't create directory '/loongarch64-alpine-linux-musl/etc/apk/keys': File exists
44.19 ok 23 386-c++-lld
45.49 ok 24 darwin-setup
```