### PR TITLE
xx-apk: fix missing versionGTE

### DIFF
--- a/src/xx-apk
+++ b/src/xx-apk
@@ -140,6 +140,8 @@ cmd() {
   fi
 }
 
+versionGTE() { test "$(printf '%s\n' "$@" | sort -V | tail -n 1)" = "$1"; }
+
 supportRiscV() {
   versionGTE "$(xx-info os-version | cut -d'.' -f1-2)" "3.20"
 }


### PR DESCRIPTION
relates to https://github.com/tonistiigi/xx/actions/runs/12260503696/job/34205276385#step:5:875

```
#92 111.6 not ok 55 loong64-hellocgo
#92 111.6 # (from function `assert_success' in file bats-assert/src/assert.bash, line 114,
#92 111.6 #  from function `testHelloCGO' in file test-go.bats, line 428,
#92 111.6 #  in test file test-go.bats, line 476)
#92 111.6 #   `testHelloCGO' failed
#92 111.6 # /usr/bin/xx-apk: line 149: versionGTE: not found
#92 111.6 # fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/main/loongarch64/APKINDEX.tar.gz
#92 111.6 # fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/community/loongarch64/APKINDEX.tar.gz
#92 111.6 # (1/1) Installing alpine-keys (2.5-r0)
#92 111.6 # OK: 0 MiB in 1 packages
#92 111.6 # + apk  --root /loongarch64-alpine-linux-musl add musl-dev gcc
```