### PR TITLE
test(clang): suppress error message on clean

### DIFF
--- a/src/test-clang.bats
+++ b/src/test-clang.bats
@@ -4,12 +4,12 @@ load 'assert'
 load 'test_helper'
 
 clean() {
-  rm /etc/llvm/xx-default.cfg || true
-  rm /usr/bin/*-linux-*-clang || true
-  rm /usr/bin/*-linux-*-clang++ || true
-  rm /usr/bin/*-apple-*-clang || true
-  rm /usr/bin/*-apple-*-clang++ || true
-  rm /usr/bin/*.cfg || true
+  rm /etc/llvm/xx-default.cfg 2>/dev/null || true
+  rm /usr/bin/*-linux-*-clang 2>/dev/null || true
+  rm /usr/bin/*-linux-*-clang++ 2>/dev/null || true
+  rm /usr/bin/*-apple-*-clang 2>/dev/null || true
+  rm /usr/bin/*-apple-*-clang++ 2>/dev/null || true
+  rm /usr/bin/*.cfg 2>/dev/null || true
 }
 
 testHelloCLLD() {


### PR DESCRIPTION
relates to https://github.com/tonistiigi/xx/actions/runs/12260586308/job/34205579093#step:5:879

```
> [test-clang test-clang 2/2] RUN --mount=type=cache,target=/pkg-cache,sharing=locked ./test-clang.bats:
43.15 #  in test file test-clang.bats, line 313)
43.15 #   `testHelloCPPLLD' failed
43.15 # rm: can't remove '/etc/llvm/xx-default.cfg': No such file or directory
43.15 # rm: can't remove '/usr/bin/*-apple-*-clang': No such file or directory
43.16 # rm: can't remove '/usr/bin/*-apple-*-clang++': No such file or directory
```