### PR TITLE
ci: remove bullseye-backports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,10 +57,6 @@ jobs:
             base: alpine
             allow-failure: true
           -
-            image: debian:bullseye-backports
-            base: debian
-            allow-failure: true
-          -
             image: debian:bookworm
             base: debian
             allow-failure: false


### PR DESCRIPTION
repo is archived https://archive.debian.org/debian/dists/bullseye-backports/

```
#21 [test-base-debian 2/3] RUN --mount=type=cache,target=/pkg-cache     rm -rf /var/cache/apt/archives &&     ln -s /pkg-cache /var/cache/apt/archives &&     rm /etc/apt/apt.conf.d/docker-clean &&     echo 'Binary::apt::APT::Keep-Downloaded-Packages "1";' > /etc/apt/apt.conf.d/keep-downloads &&     apt update && apt install --no-install-recommends -y bash vim
#21 0.127 
#21 0.127 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
#21 0.127 
#21 0.209 Get:1 http://deb.debian.org/debian bullseye InRelease [75.1 kB]
#21 0.217 Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [27.2 kB]
#21 0.217 Get:3 http://deb.debian.org/debian bullseye-updates InRelease [44.0 kB]
#21 0.217 Ign:4 http://deb.debian.org/debian bullseye-backports InRelease
#21 0.220 Err:5 http://deb.debian.org/debian bullseye-backports Release
#21 0.220   404  Not Found [IP: 151.101.202.132 80]
#21 0.303 Get:6 http://deb.debian.org/debian bullseye/main amd64 Packages [8066 kB]
#21 0.389 Get:7 http://deb.debian.org/debian-security bullseye-security/main amd64 Packages [394 kB]
#21 0.471 Get:8 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [18.8 kB]
#21 1.175 Reading package lists...
#21 1.564 E: The repository 'http://deb.debian.org/debian bullseye-backports Release' does not have a Release file.
#21 ERROR: process "/bin/sh -c rm -rf /var/cache/apt/archives &&     ln -s /pkg-cache /var/cache/apt/archives &&     rm /etc/apt/apt.conf.d/docker-clean &&     echo 'Binary::apt::APT::Keep-Downloaded-Packages \"1\";' > /etc/apt/apt.conf.d/keep-downloads &&     apt update && apt install --no-install-recommends -y bash vim" did not complete successfully: exit code: 100
```
