### PR TITLE
feat(xx-cargo): support Cargo wrappers through `XX_CARGO` env var

### DIFF
--- a/src/xx-cargo
+++ b/src/xx-cargo
@@ -106,5 +106,5 @@ if [ -n "$printtarget" ]; then
 fi
 
 if [ -z "$setuponly" ]; then
-  exec cargo "$@" --target="$(xx-info)"
+  exec "${XX_CARGO:-cargo}" "$@" --target="$(xx-info)"
 fi


### PR DESCRIPTION
Some Rust projects are meant to be built with Cargo wrappers that maintain most of the relevant Cargo CLI, but add additional build logic on top. Examples include projects using the Dioxus or Tauri frameworks.

In order to make such wrappers composable with `xx`, let's add a `XX_CARGO` environment variable users can set to make `xx-cargo` run them.