### PR TITLE
xx-info: darwin: use macOS 11.0 as default deployment target for arm64

### DIFF
--- a/src/test-clang.bats
+++ b/src/test-clang.bats
@@ -360,12 +360,12 @@ testBuildHello() {
 
   export TARGETARCH=arm64
   xx-clang --setup-target-triple
-  [ -f /usr/bin/arm64-apple-macos10.16-clang ]
-  [ -f /usr/bin/arm64-apple-macos10.16-clang++ ]
+  [ -f /usr/bin/arm64-apple-macos11.0-clang ]
+  [ -f /usr/bin/arm64-apple-macos11.0-clang++ ]
 
-  run cat /usr/bin/arm64-apple-macos10.16.cfg
+  run cat /usr/bin/arm64-apple-macos11.0.cfg
   assert_success
-  assert_output "--target=arm64-apple-macos10.16 -fuse-ld=ld64 -isysroot /xx-sdk/MacOSX11.1.sdk -stdlib=libc++"
+  assert_output "--target=arm64-apple-macos11.0 -fuse-ld=ld64 -isysroot /xx-sdk/MacOSX11.1.sdk -stdlib=libc++"
 
   touch /usr/bin/ld64.signed
   chmod +x /usr/bin/ld64.signed
@@ -373,23 +373,23 @@ testBuildHello() {
   clean
 
   xx-clang --setup-target-triple
-  [ -f /usr/bin/arm64-apple-macos10.16-clang ]
-  [ -f /usr/bin/arm64-apple-macos10.16-clang++ ]
+  [ -f /usr/bin/arm64-apple-macos11.0-clang ]
+  [ -f /usr/bin/arm64-apple-macos11.0-clang++ ]
 
-  run cat /usr/bin/arm64-apple-macos10.16.cfg
+  run cat /usr/bin/arm64-apple-macos11.0.cfg
   assert_success
-  assert_output "--target=arm64-apple-macos10.16 -fuse-ld=/usr/bin/ld64.signed -isysroot /xx-sdk/MacOSX11.1.sdk -stdlib=libc++"
+  assert_output "--target=arm64-apple-macos11.0 -fuse-ld=/usr/bin/ld64.signed -isysroot /xx-sdk/MacOSX11.1.sdk -stdlib=libc++"
 
   clean
 
   mkdir -p /xx-sdk/MacOSX11.2.sdk
   xx-clang --setup-target-triple
-  [ -f /usr/bin/arm64-apple-macos10.16-clang ]
-  [ -f /usr/bin/arm64-apple-macos10.16-clang++ ]
+  [ -f /usr/bin/arm64-apple-macos11.0-clang ]
+  [ -f /usr/bin/arm64-apple-macos11.0-clang++ ]
 
-  run cat /usr/bin/arm64-apple-macos10.16.cfg
+  run cat /usr/bin/arm64-apple-macos11.0.cfg
   assert_success
-  assert_output "--target=arm64-apple-macos10.16 -fuse-ld=/usr/bin/ld64.signed -isysroot /xx-sdk/MacOSX11.2.sdk -stdlib=libc++"
+  assert_output "--target=arm64-apple-macos11.0 -fuse-ld=/usr/bin/ld64.signed -isysroot /xx-sdk/MacOSX11.2.sdk -stdlib=libc++"
 
   rm -r /xx-sdk/MacOSX11.2.sdk
   rm /usr/bin/ld64.signed

--- a/src/test-info-alpine.bats
+++ b/src/test-info-alpine.bats
@@ -127,7 +127,7 @@ load 'assert'
   assert_equal "amd64" "$(TARGETPLATFORM=darwin/amd64 xx-info arch)"
   assert_equal "x86_64" "$(TARGETPLATFORM=darwin/amd64 xx-info march)"
   assert_equal "arm64" "$(TARGETPLATFORM=darwin/arm64 xx-info march)"
-  assert_equal "arm64-apple-macos10.16" "$(TARGETPLATFORM=darwin/arm64 xx-info triple)"
+  assert_equal "arm64-apple-macos11.0" "$(TARGETPLATFORM=darwin/arm64 xx-info triple)"
   assert_equal "x86_64-apple-macos10.15" "$(TARGETPLATFORM=darwin/amd64 MACOSX_VERSION_MIN=10.15 xx-info triple)"
   assert_equal "apple" "$(TARGETPLATFORM=darwin/amd64 xx-info vendor)"
 }

--- a/src/xx-info
+++ b/src/xx-info
@@ -216,11 +216,16 @@ if [ "$TARGETARCH" = "arm" ] && [ -z "$TARGETVARIANT" ]; then
   TARGETVARIANT="v7"
 fi
 
+# Default deployment targets for Darwin.
+#
+# Keep 10.6 for Intel. Apple Silicon starts at macOS 11; older toolchains
+# used "10.16" as an alias for Big Sur, but newer Clang maps it to "11.0"
+# and warns about the override.
 if [ "$TARGETOS" = "darwin" ] && [ -z "$MACOSX_VERSION_MIN" ]; then
   if [ "$TARGETARCH" = "amd64" ]; then
     MACOSX_VERSION_MIN=10.6
   else
-    MACOSX_VERSION_MIN=10.16
+    MACOSX_VERSION_MIN=11.0
   fi
 fi
 


### PR DESCRIPTION
- relates to https://github.com/docker/compose/pull/13921
- relates to https://github.com/docker/docker-credential-helpers/issues/280

Apple Silicon requires macOS 11. Newer Clang versions canonicalize the historical "10.16" deployment target to "11.0", emitting `-Woverriding-deployment-version`. This becomes a build failure when warnings are treated as errors (for example by Go's runtime/cgo);

    GO111MODULE=on go build  -trimpath -tags "fsnotify,e2e" -ldflags "-w -X github.com/docker/compose/v5/internal.Version=61203c8" -o "/out/docker-compose" ./cmd
    # runtime/cgo
    clang: error: overriding deployment version from '10.16' to '11.0' [-Werror,-Woverriding-deployment-version]

Update `MACOSX_VERSION_MIN` to use 11.0 as the default deployment target for darwin/arm64 instead.