### PR TITLE
fix LoongArch detection across toolchains and package managers

### DIFF
--- a/src/test-clang.bats
+++ b/src/test-clang.bats
@@ -32,7 +32,7 @@ testHelloCLLD() {
     assert_success
     assert_output "-fuse-ld=lld"
   else
-    if [ -z "$expectedLinker"]; then expectedLinker="lld"; fi
+    if [ -z "$expectedLinker" ]; then expectedLinker="lld"; fi
     if [ -f /etc/alpine-release ]; then
       assert_output "--target=$(xx-info triple) -fuse-ld=$expectedLinker --sysroot=/$(xx-info triple)/$expectedSuffix"
     else
@@ -259,7 +259,7 @@ testBuildHello() {
   testHelloCLLD
 }
 
-@test "loong64-c-ld" {
+@test "loong64-c-lld" {
   if ! supportLoongArch; then
     skip "LOONGARCH64 not supported"
   fi

--- a/src/test-info-common.bats
+++ b/src/test-info-common.bats
@@ -86,7 +86,7 @@ load 'assert'
 }
 
 @test "loong64" {
-  assert_equal "loong64" "$(TARGETPLATFORM=linux/loong64 xx-info march)"
+  assert_equal "loongarch64" "$(TARGETPLATFORM=linux/loong64 xx-info march)"
 }
 
 @test "mips" {

--- a/src/test-info-rhel.bats
+++ b/src/test-info-rhel.bats
@@ -61,7 +61,7 @@ fi
 }
 
 @test "loong64" {
-  assert_equal "loong64" "$(TARGETPLATFORM=linux/loong64 xx-info pkg-arch)"
+  assert_equal "loongarch64" "$(TARGETPLATFORM=linux/loong64 xx-info pkg-arch)"
 }
 
 @test "mips" {

--- a/src/xx-cc
+++ b/src/xx-cc
@@ -175,7 +175,7 @@ detectTargetOSArch() {
     targetarch="s390x"
   elif [ "$arch" = "powerpc64le" ]; then
     targetarch="ppc64le"
-  elif [ "$arch" = "loong64" ]; then
+  elif [ "$arch" = "loongarch64" ]; then
     targetarch="loong64"
   fi
 

--- a/src/xx-cc
+++ b/src/xx-cc
@@ -344,11 +344,6 @@ setup() {
   if [ "${target#riscv64}" != "${target}" ]; then
     prefer_lld=
   fi
-  # lld has no support for loong64
-  if [ "${target#loong64}" != "${target}" ]; then
-    prefer_lld=
-  fi
-
   if [ -n "${XX_CC_PREFER_STATIC_LINKER}" ] && { [ "${target#386}" != "${target}" ] || [ "${target#powerpc64le}" != "${target}" ]; }; then
     prefer_lld=
   fi

--- a/src/xx-info
+++ b/src/xx-info
@@ -190,7 +190,7 @@ if [ -z "$TARGETARCH" ]; then
     "s390x")
       TARGETARCH="s390x"
       ;;
-    "loong64")
+    "loongarch64")
       TARGETARCH="loong64"
       ;;
     "mips")
@@ -315,10 +315,10 @@ case "$TARGETARCH" in
     XX_TRIPLE="s390x${vendor}-linux-${XX_LIBC}"
     ;;
   "loong64")
-    XX_MARCH="loong64"
+    XX_MARCH="loongarch64"
     XX_DEBIAN_ARCH="loong64"
     XX_ALPINE_ARCH="loongarch64"
-    XX_RHEL_ARCH="loong64"
+    XX_RHEL_ARCH="loongarch64"
     XX_TRIPLE="loongarch64${vendor}-linux-${XX_LIBC}"
     ;;
   "386")


### PR DESCRIPTION
carry and closes https://github.com/tonistiigi/xx/pull/223 as I can't push last commit.

This fixes LoongArch naming so `xx-info` reports the names expected by Linux, RPM, Alpine, Debian, and the GNU toolchain.

The Docker and Go architecture remains `loong64`, while the machine architecture, RPM architecture, Alpine architecture, and compiler triple use `loongarch64` where those ecosystems expect it. The `xx-cc` LoongArch linker path was also cleaned up so the supported `lld` flow remains enabled.

cc @wojiushixiaobai