### PR TITLE
fixes for 1.10

### DIFF
--- a/src/test-apk.bats
+++ b/src/test-apk.bats
@@ -23,6 +23,14 @@ load 'assert'
   assert_success
 }
 
+@test "essentials can be listed together" {
+  run xx-apk list xx-c-essentials xx-cxx-essentials
+  assert_success
+  assert_output --partial "musl-dev"
+  assert_output --partial "gcc"
+  assert_output --partial "g++"
+}
+
 @test "cross" {
   target="arm64"
   if [ "$(xx-info arch)" = "arm64" ]; then target="amd64"; fi

--- a/src/test-apt.bats
+++ b/src/test-apt.bats
@@ -31,6 +31,65 @@ load 'test_helper'
   assert_success
 }
 
+@test "fix-source-file-deb822" {
+  f="$BATS_TEST_TMPDIR/test.sources"
+  cat >"$f" <<EOF
+Types: deb deb-src
+URIs: http://archive.ubuntu.com/ubuntu/
+Suites: noble noble-updates
+Components: main universe
+
+Types: deb
+URIs: http://security.ubuntu.com/ubuntu/
+Suites: noble-security
+Components: main universe
+EOF
+
+  run xx-apt --fix-source-file "$f" arm64
+  assert_success
+  # rerunning must not duplicate the fields
+  run xx-apt --fix-source-file "$f" arm64
+  assert_success
+
+  run diff "$f" - <<EOF
+Types: deb deb-src
+Architectures: arm64
+URIs: http://archive.ubuntu.com/ubuntu/
+Suites: noble noble-updates
+Components: main universe
+
+Types: deb
+Architectures: arm64
+URIs: http://security.ubuntu.com/ubuntu/
+Suites: noble-security
+Components: main universe
+EOF
+  assert_success
+}
+
+@test "fix-source-file-classic" {
+  f="$BATS_TEST_TMPDIR/sources.list"
+  cat >"$f" <<EOF
+deb http://archive.ubuntu.com/ubuntu/ noble main universe
+deb-src http://archive.ubuntu.com/ubuntu/ noble main universe
+# deb http://archive.ubuntu.com/ubuntu/ noble-backports main
+deb [arch=riscv64] http://ports.ubuntu.com/ubuntu-ports/ noble main
+EOF
+
+  run xx-apt --fix-source-file "$f" arm64
+  assert_success
+  run xx-apt --fix-source-file "$f" arm64
+  assert_success
+
+  run diff "$f" - <<EOF
+deb [arch=arm64] http://archive.ubuntu.com/ubuntu/ noble main universe
+deb-src [arch=arm64] http://archive.ubuntu.com/ubuntu/ noble main universe
+# deb [arch=arm64] http://archive.ubuntu.com/ubuntu/ noble-backports main
+deb [arch=riscv64] http://ports.ubuntu.com/ubuntu-ports/ noble main
+EOF
+  assert_success
+}
+
 @test "amd64" {
   export TARGETARCH=amd64
   if ! xx-info is-cross; then skip; fi

--- a/src/test-clang.bats
+++ b/src/test-clang.bats
@@ -209,6 +209,27 @@ testBuildHello() {
   testHelloCPPLLD
 }
 
+@test "xx-cc and xx-c++ aliases use target platform from env" {
+  clean
+  add clang lld
+
+  targetArch="arm64"
+  if [ "$(TARGETPLATFORM= TARGETARCH= TARGETOS= TARGETPAIR= xx-info arch)" = "arm64" ]; then
+    targetArch="amd64"
+  fi
+
+  export TARGETPLATFORM="linux/${targetArch}"
+  expectedTriple="$(xx-info triple)"
+
+  for compiler in xx-cc xx-c++; do
+    run "$compiler" --print-target-triple
+    assert_success
+    assert_output "$expectedTriple"
+  done
+
+  unset TARGETPLATFORM
+}
+
 @test "amd64-c-lld" {
   export TARGETARCH=amd64
   testHelloCLLD

--- a/src/test-info-common.bats
+++ b/src/test-info-common.bats
@@ -16,6 +16,19 @@ load 'assert'
   [ "$output" != "" ]
 }
 
+@test "missing os-release uses generic linux fallback" {
+  if [ ! -e /etc/os-release ]; then
+    skip "/etc/os-release already missing"
+  fi
+
+  mv /etc/os-release /tmp/os-release.bak
+  TARGETPLATFORM=linux/arm64 run xx-info triple
+  mv /tmp/os-release.bak /etc/os-release
+
+  assert_success
+  assert_output "aarch64-unknown-linux-gnu"
+}
+
 @test "is-cross" {
   run xx-info is-cross
   assert_failure

--- a/src/test-info-common.bats
+++ b/src/test-info-common.bats
@@ -52,6 +52,32 @@ load 'assert'
   assert_output "bar"
 }
 
+@test "unmapped targets fail for mapped outputs" {
+  TARGETPLATFORM=linux/ppc64 run xx-info triple
+  assert_failure
+  assert_output --partial "unsupported target: os=linux arch=ppc64"
+
+  TARGETPAIR=linux-amd64v3 run xx-info
+  assert_failure
+  assert_output --partial "unsupported target: os=linux arch=amd64v3"
+
+  tmpbin="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$tmpbin"
+  cat >"$tmpbin/uname" <<'EOF'
+#!/usr/bin/env sh
+if [ "$1" = "-m" ]; then
+  echo not-a-machine
+  exit 0
+fi
+exec /bin/uname "$@"
+EOF
+  chmod +x "$tmpbin/uname"
+
+  PATH="$tmpbin:$PATH" run xx-info triple
+  assert_failure
+  assert_output --partial "unsupported target: os=linux arch=unknown"
+}
+
 @test "default arm variant" {
   assert_equal "" "$(TARGETARCH=amd64 xx-info variant)"
   assert_equal "v7" "$(TARGETARCH=arm xx-info variant)"

--- a/src/test-verify.bats
+++ b/src/test-verify.bats
@@ -72,6 +72,43 @@ load 'assert'
   unset TARGETPLATFORM
 }
 
+@test "static-multi-file" {
+  # XX_VERIFY_FILE_CMD_OUTPUT applies the same output to every file, so
+  # multi-file verification needs real files that file(1) classifies
+  # differently. These are handcrafted minimal ELF64 x86-64 executables
+  # (no toolchain in the test image): one with no dynamic section
+  # ("statically linked"), one with PT_INTERP+PT_DYNAMIC ("dynamically
+  # linked"). file(1) reads only the headers, so the host arch is irrelevant.
+  staticbin="$BATS_TEST_TMPDIR/static-amd64"
+  dynbin="$BATS_TEST_TMPDIR/dynamic-amd64"
+  base64 -d >"$staticbin" <<'EOF'
+f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAFAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAAgAAAAAAAAACAAAAAAAAAAAAQAAAAAAAA
+EOF
+  base64 -d >"$dynbin" <<'EOF'
+f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAADAAAAAAAAAAEAAAAFAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAAJAEAAAAAAAAkAQAAAAAAAAAQAAAAAAAAAwAAAAQAAADoAAAAAAAAAOgAQAAAAAAA6ABAAAAAAAAcAAAAAAAAABwAAAAAAAAAAQAAAAAAAAACAAAABgAAAAQBAAAAAAAABAFAAAAAAAAEAUAAAAAAACAAAAAAAAAAIAAAAAAAAAAIAAAAAAAAAC9saWI2NC9sZC1saW51eC14ODYtNjQuc28uMgABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+EOF
+  export TARGETPLATFORM=linux/amd64
+
+  run xx-verify --static "$staticbin"
+  assert_success
+
+  run xx-verify --static "$dynbin"
+  assert_failure
+  assert_output --partial "not statically linked"
+
+  run xx-verify --static "$staticbin" "$staticbin"
+  assert_success
+
+  run xx-verify --static "$staticbin" "$dynbin"
+  assert_failure
+  assert_output --partial "not statically linked"
+
+  run xx-verify --static "$staticbin" /idontexist
+  assert_failure
+
+  unset TARGETPLATFORM
+}
+
 @test "darwin" {
   export XX_VERIFY_FILE_CMD_OUTPUT=": Mach-O 64-bit executable x86_64"
   export TARGETPLATFORM=darwin/amd64

--- a/src/test-windres.bats
+++ b/src/test-windres.bats
@@ -19,6 +19,18 @@ load 'test_helper'
   run xx-windres -foo foobar
   assert_failure
   assert_output "invalid option -foo"
+
+  run xx-windres -J foo myinp.rc myout.syso
+  assert_failure
+  assert_output "invalid input format foo"
+
+  run xx-windres -O foo myinp.rc myout.syso
+  assert_failure
+  assert_output "invalid output format foo"
+
+  run xx-windres -F pe-mips myinp.rc myout.syso
+  assert_failure
+  assert_output "invalid target pe-mips for xx-windres"
 }
 
 @test "basic" {

--- a/src/test-windres.bats
+++ b/src/test-windres.bats
@@ -3,6 +3,16 @@
 load 'assert'
 load 'test_helper'
 
+@test "version" {
+  run xx-windres --version
+  assert_success
+  assert_output "xx-windres 0.1"
+
+  run xx-windres -V
+  assert_success
+  assert_output "xx-windres 0.1"
+}
+
 @test "invalid" {
   add llvm
 

--- a/src/test-windres.bats
+++ b/src/test-windres.bats
@@ -29,10 +29,10 @@ load 'test_helper'
   export TARGETPLATFORM=windows/arm
   export XX_TMP_FILE_FIXED=/tmp/foo
   export CC=clang
-  run xx-windres -i myinp.rc -o myout.syso --use-temp-file -I /foo -D FOO=bar -UNOT -DABC=def
+  run xx-windres -i myinp.rc -o myout.syso --use-temp-file -I /foo --include-dir /bar --include-dir=/baz -D FOO=bar -UNOT -DABC=def
   assert_success
   assert_output <<EOT
-clang -E -xc -D RC_INVOKED=1 -I/foo -D FOO=bar -U NOT -D ABC=def -o /tmp/foo myinp.rc
+clang -E -xc -D RC_INVOKED=1 -I/foo -I/bar -I/baz -D FOO=bar -U NOT -D ABC=def -o /tmp/foo myinp.rc
 llvm-rc -fo /tmp/foo_ -I . /tmp/foo
 llvm-cvtres -machine:ARM -out:myout.syso /tmp/foo_
 EOT

--- a/src/xx-apk
+++ b/src/xx-apk
@@ -95,11 +95,14 @@ cmd() {
   if xx-info is-cross; then
     root="/${XX_TRIPLE}"
   fi
-  n=$#
   iscompilerrt=
   isrustlib=
+  first=1
   for a in "$@"; do
-    if [ $# = $n ]; then set --; fi
+    if [ -n "$first" ]; then
+      set --
+      first=
+    fi
     case "$a" in
       "xx-c-essentials")
         set -- "$@" musl-dev gcc

--- a/src/xx-apt
+++ b/src/xx-apt
@@ -198,10 +198,14 @@ if ! xx-info is-cross; then
   nocross=1
 fi
 
-if [ "$TARGETARCH" = "riscv64" ] && [ "$(xx-info vendor)" = "debian" ]; then
-  apt-get update
-  apt-get install -y debian-ports-archive-keyring
-  echo "deb [ arch=riscv64 ] http://ftp.ports.debian.org/debian-ports sid main" >>/etc/apt/sources.list.d/riscv64-sid.list
+if [ "$TARGETARCH" = "riscv64" ] && [ "$(xx-info vendor)" = "debian" ] && [ "$(cut -d. -f 1 /etc/debian_version)" -lt 13 ]; then
+  riscv64_sid_list=/etc/apt/sources.list.d/riscv64-sid.list
+  riscv64_sid_repo="deb [ arch=riscv64 ] http://ftp.ports.debian.org/debian-ports sid main"
+  if ! grep -Fx "$riscv64_sid_repo" "$riscv64_sid_list" >/dev/null 2>&1; then
+    apt-get update
+    apt-get install -y debian-ports-archive-keyring
+    echo "$riscv64_sid_repo" >>"$riscv64_sid_list"
+  fi
 fi
 
 if ! dpkg --print-foreign-architectures | grep "$XX_PKG_ARCH" >/dev/null; then

--- a/src/xx-apt
+++ b/src/xx-apt
@@ -44,12 +44,31 @@ check_deb822() {
   [ "$(printf '%s' $(aptsourcesfile) | awk -F . '{if (NF>1) {print $NF}}')" = "sources" ] && return 0 || return 1
 }
 
+# restrict all repositories in a sources file to the given architecture
+fixsourcesfile() {
+  case "$1" in
+    *.sources)
+      if ! grep -q "^Architectures:" "$1"; then
+        sed -E "s/^(Types:.*)/\1\nArchitectures: $2/" -i "$1"
+      fi
+      ;;
+    *)
+      sed -E "/arch=/! s/^(# )?(deb|deb-src) /\1\2 [arch=$2] /" -i "$1"
+      ;;
+  esac
+}
+
 exitnolinux() {
   if [ "${TARGETOS}" != "linux" ]; then
     echo >&2 "skipping packages installation on ${XX_OS}"
     exit 0
   fi
 }
+
+if [ "$1" = "--fix-source-file" ]; then
+  fixsourcesfile "$2" "$3"
+  exit 0
+fi
 
 n=$#
 for a in "$@"; do
@@ -102,11 +121,7 @@ fi
 fixubuntusources() {
   # fix all current sources to native arch
   nativearch="$(TARGETPLATFORM="" TARGETPAIR="" TARGETARCH="" TARGETOS="" xx-info arch)"
-  if ! check_deb822; then
-    sed -E "/arch=/! s/^(# )?(deb|deb-src) /\1\2 [arch=$nativearch] /" -i "$(aptsourcesfile)"
-  else
-    sed -E "/Architectures:/! s/^(Types\: [a-z]+)/\1\nArchitectures: $nativearch/" -i "$(aptsourcesfile)"
-  fi
+  fixsourcesfile "$(aptsourcesfile)" "$nativearch"
 
   if ! xx-info is-cross; then return; fi
 

--- a/src/xx-cc
+++ b/src/xx-cc
@@ -278,6 +278,10 @@ download_ld() {
 
 basename=$(basename "$0")
 name=${basename#xx-}
+wrapped=
+if [ "xx-$name" = "$basename" ]; then
+  wrapped=1
+fi
 
 # XX_CC_PREFER_LINKER defines the linker to use if the compiler supports it
 : "${XX_CC_PREFER_LINKER=lld}"
@@ -290,11 +294,6 @@ fi
 
 if [ "$name" = "c++" ]; then
   name="clang++"
-fi
-
-wrapped=
-if [ "xx-$name" = "$basename" ]; then
-  wrapped=1
 fi
 
 if [ -f /.xx-cc-autowrap ]; then

--- a/src/xx-info
+++ b/src/xx-info
@@ -384,6 +384,22 @@ case "$XX_VENDOR" in
     ;;
 esac
 
+requires_target_mapping() {
+  case "$1" in
+    "arch" | "variant" | "os" | "os-version" | "vendor" | "libc" | "--help")
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+if requires_target_mapping "$1"; then
+  if [ -z "$TARGETARCH" ] || [ "$XX_MARCH" = "unknown" ] || [ "$XX_TRIPLE" = "unknown-unknown-none" ]; then
+    echo >&2 "unsupported target: os=${TARGETOS:-unknown} arch=${TARGETARCH:-unknown} variant=${TARGETVARIANT:-}"
+    exit 1
+  fi
+fi
+
 case "$1" in
   "is-cross")
     if [ "$XX_MARCH" = "$(uname -m)" ] && [ "$TARGETOS" = "linux" ]; then

--- a/src/xx-info
+++ b/src/xx-info
@@ -121,7 +121,8 @@ fi
 distro=""
 # detect distro vendor
 # shellcheck disable=SC1091
-if . /etc/os-release 2>/dev/null; then
+if [ -r /etc/os-release ]; then
+  . /etc/os-release
   distro=$ID
   XX_OS_VERSION=$VERSION_ID
 fi

--- a/src/xx-verify
+++ b/src/xx-verify
@@ -21,9 +21,16 @@ if [ -n "$XX_DEBUG_VERIFY" ]; then
   set -x
 fi
 
-for l in $(xx-info env); do
-  export "${l?}"
-done
+if envout=$(xx-info env 2>/dev/null); then
+  for l in $envout; do
+    export "${l?}"
+  done
+else
+  TARGETOS="$(xx-info os)"
+  TARGETARCH="$(xx-info arch)"
+  TARGETVARIANT="$(xx-info variant)"
+  export TARGETOS TARGETARCH TARGETVARIANT
+fi
 
 setup() {
   if ! command -v file >/dev/null 2>/dev/null; then

--- a/src/xx-verify
+++ b/src/xx-verify
@@ -268,15 +268,16 @@ for f in "$@"; do
   fi
 
   if [ "$static" = "1" ] && { [ "$TARGETOS" = "linux" ] || [ "$TARGETOS" = "freebsd" ]; }; then
+    staticok=
     if echo "$out" | grep -E "statically linked|static-pie" >/dev/null; then
-      exit 0
+      staticok=1
+    elif echo "$out" | grep " pie " | grep -v ", interpreter " >/dev/null; then
+      staticok=1
     fi
-    if echo "$out" | grep " pie " | grep -v ", interpreter " >/dev/null; then
-      exit 0
+    if [ -z "$staticok" ]; then
+      echo >&2 "file ${f} is not statically linked: $out"
+      exit 1
     fi
-
-    echo >&2 "file ${f} is not statically linked: $out"
-    exit 1
   fi
 
 done

--- a/src/xx-windres
+++ b/src/xx-windres
@@ -103,7 +103,8 @@ while :; do
       exit
       ;;
     -V | --version)
-      "xx-windres 0.1"
+      echo "xx-windres 0.1"
+      exit 0
       ;;
     -o | --output)
       isnextarg "$1" "$2"

--- a/src/xx-windres
+++ b/src/xx-windres
@@ -177,10 +177,13 @@ while :; do
     --preprocessor-arg=*)
       preprocessorargs="$preprocessorargs ${1#--preprocessor-arg=}"
       ;;
-    -I | --include-path)
+    -I | --include-dir | --include-path)
       isnextarg "$1" "$2"
       preprocessorargs="$preprocessorargs -I$2"
       shift
+      ;;
+    --include-dir=*)
+      preprocessorargs="$preprocessorargs -I${1#--include-dir=}"
       ;;
     --include-path=*)
       preprocessorargs="$preprocessorargs -I${1#--include-path=}"

--- a/src/xx-windres
+++ b/src/xx-windres
@@ -290,6 +290,7 @@ fi
 
 if [ "$inputf" != "res" ] && [ "$inputf" != "rc" ]; then
   echo >&2 "invalid input format $inputf"
+  exit 1
 fi
 
 if [ -z "$outputf" ]; then
@@ -304,6 +305,7 @@ fi
 
 if [ "$outputf" != "coff" ] && [ "$outputf" != "res" ]; then
   echo >&2 "invalid output format $outputf"
+  exit 1
 fi
 
 machine=
@@ -322,6 +324,7 @@ case $target in
     ;;
   *)
     echo >&2 "invalid target $target for xx-windres"
+    exit 1
     ;;
 esac
 


### PR DESCRIPTION
This fixes a set of silent failure and wrong-result paths across the `xx` shell helpers.

- Fix `xx-cc` / `xx-c++` alias wrapper detection so both aliases honor `TARGETPLATFORM` instead of falling through to native clang targets.
- Fix `xx-verify --static` multi-file verification so it checks every input instead of exiting after the first static binary.
- Make `xx-info` tolerate missing `/etc/os-release` by using the existing generic linux fallback.
- Make `xx-info` fail loudly for unmapped targets instead of returning `unknown-unknown-none` with exit code 0.
- Fix `xx-apk` meta-package argument expansion so combined `xx-c-essentials` / `xx-cxx-essentials` invocations preserve all args.
- Fix `xx-apt` Debian riscv64 sid repo handling so Debian 13+ does not get a sid ports repo and repeated runs do not duplicate entries.
- Fix `xx-apt` deb822 source rewriting for `Types: deb deb-src` and idempotent `Architectures:` insertion.
- Fix `xx-windres` version flags, `--include-dir` parsing, and invalid `-J` / `-O` / `-F` value exits.
